### PR TITLE
Move openmm docs into a docs/openmm/ subdirectory

### DIFF
--- a/openmm/build.sh
+++ b/openmm/build.sh
@@ -62,3 +62,7 @@ cd ..
 # Copy all tests to bin directory so they will be distributed with install package.
 #cp `find . -name "Test*" -type f -maxdepth 1` $PREFIX/bin
 
+# Put docs into a subdirectory.
+cd $PREFIX/docs
+mkdir openmm
+mv *.pdf *.html api-* openmm/


### PR DESCRIPTION
The OpenMM docs are now all installed under `$CONDAHOME/docs/openmm/` rather than being just dropped into `$CONDAHOME/docs` (where `$CONDAHOME` is shorthand for the local conda environment).
