### PR TITLE
Add munkres package

### DIFF
--- a/munkres/bld.bat
+++ b/munkres/bld.bat
@@ -1,0 +1,2 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1

--- a/munkres/build.sh
+++ b/munkres/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+$PYTHON setup.py install

--- a/munkres/meta.yaml
+++ b/munkres/meta.yaml
@@ -1,0 +1,26 @@
+package:
+  name: munkres
+  version: !!str 1.0.7
+
+source:
+  fn: munkres-1.0.7.tar.gz
+  url: https://pypi.python.org/packages/source/m/munkres/munkres-1.0.7.tar.gz
+  md5: d534612326f7c7cadcfa61d109f96289
+
+requirements:
+  build:
+    - python
+
+  run:
+    - python
+
+test:
+  # Python imports
+  imports:
+    - munkres
+
+
+about:
+  home: http://software.clapper.org/munkres/
+  license:  BSD License
+  summary: 'munkres algorithm for the Assignment Problem'


### PR DESCRIPTION
Also used in testing MSMBuilder, like #53. With these on binstar, I think I'll be able to run the build and test on travis without `pip`.
