### PR TITLE
Fixed post-link script to eliminate non-OSX-compatible `mv -t`

### DIFF
--- a/openmm/build.sh
+++ b/openmm/build.sh
@@ -66,3 +66,7 @@ cd ..
 cd $PREFIX/docs
 mkdir openmm
 mv *.pdf *.html api-* openmm/
+
+# Put examples into an appropriate subdirectory.
+mkdir $PREFIX/share/openmm/
+mv $PREFIX/examples $PREFIX/share/openmm/

--- a/openmm/post-link.sh
+++ b/openmm/post-link.sh
@@ -23,15 +23,3 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
 
 fi
 
-# For anaconda installs, the OpenMM examples should probably go in ~/anaconda/share/examples/openmm/
-# Now we handle this manually, in the future we should probably add an extra flag in
-# CMAKE to make this cleaner.
-rm -rf $PREFIX/share/openmm/examples
-mkdir -p $PREFIX/share/openmm/examples
-
-mv $PREFIX/examples/simulateAmber.py $PREFIX/examples/simulatePdb.py $PREFIX/examples/simulateGromacs.py $PREFIX/share/openmm/examples
-mv $PREFIX/share/openmm/examples $PREFIX/examples/benchmark.py $PREFIX/examples/argon-chemical-potential.py $PREFIX/share/openmm/examples
-mv $PREFIX/share/openmm/examples $PREFIX/examples/input.inpcrd $PREFIX/examples/input.prmtop $PREFIX/examples/input.pdb $PREFIX/examples/input.gro $PREFIX/examples/input.top $PREFIX/share/openmm/examples
-mv $PREFIX/share/openmm/examples $PREFIX/examples/5dfr_minimized.pdb $PREFIX/examples/5dfr_solv-cube_equil.pdb $PREFIX/share/openmm/examples
-mv $PREFIX/share/openmm/examples $PREFIX/examples/README.txt $PREFIX/examples/Makefile $PREFIX/examples/NMakefile $PREFIX/examples/MakefileNotes.txt $PREFIX/examples/Empty.cpp
-mv $PREFIX/examples/VisualStudio $PREFIX/share/openmm/examples

--- a/openmm/post-link.sh
+++ b/openmm/post-link.sh
@@ -24,15 +24,14 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
 fi
 
 # For anaconda installs, the OpenMM examples should probably go in ~/anaconda/share/examples/openmm/
-# Now we handle this manually, in the future we should probably add an extra flag in 
+# Now we handle this manually, in the future we should probably add an extra flag in
 # CMAKE to make this cleaner.
 rm -rf $PREFIX/share/openmm/examples
 mkdir -p $PREFIX/share/openmm/examples
 
-mv -t $PREFIX/share/openmm/examples $PREFIX/examples/simulateAmber.py $PREFIX/examples/simulatePdb.py $PREFIX/examples/simulateGromacs.py 
-mv -t $PREFIX/share/openmm/examples $PREFIX/examples/benchmark.py $PREFIX/examples/argon-chemical-potential.py 
-mv -t $PREFIX/share/openmm/examples $PREFIX/examples/input.inpcrd $PREFIX/examples/input.prmtop $PREFIX/examples/input.pdb $PREFIX/examples/input.gro $PREFIX/examples/input.top 
-mv -t $PREFIX/share/openmm/examples $PREFIX/examples/5dfr_minimized.pdb $PREFIX/examples/5dfr_solv-cube_equil.pdb
-mv -t $PREFIX/share/openmm/examples $PREFIX/examples/README.txt $PREFIX/examples/Makefile $PREFIX/examples/NMakefile $PREFIX/examples/MakefileNotes.txt $PREFIX/examples/Empty.cpp
-
-mv -t $PREFIX/share/openmm/examples $PREFIX/examples/VisualStudio
+mv $PREFIX/examples/simulateAmber.py $PREFIX/examples/simulatePdb.py $PREFIX/examples/simulateGromacs.py $PREFIX/share/openmm/examples
+mv $PREFIX/share/openmm/examples $PREFIX/examples/benchmark.py $PREFIX/examples/argon-chemical-potential.py $PREFIX/share/openmm/examples
+mv $PREFIX/share/openmm/examples $PREFIX/examples/input.inpcrd $PREFIX/examples/input.prmtop $PREFIX/examples/input.pdb $PREFIX/examples/input.gro $PREFIX/examples/input.top $PREFIX/share/openmm/examples
+mv $PREFIX/share/openmm/examples $PREFIX/examples/5dfr_minimized.pdb $PREFIX/examples/5dfr_solv-cube_equil.pdb $PREFIX/share/openmm/examples
+mv $PREFIX/share/openmm/examples $PREFIX/examples/README.txt $PREFIX/examples/Makefile $PREFIX/examples/NMakefile $PREFIX/examples/MakefileNotes.txt $PREFIX/examples/Empty.cpp
+mv $PREFIX/examples/VisualStudio $PREFIX/share/openmm/examples


### PR DESCRIPTION
This should fix #61 