### PR TITLE
Update msmbuilder to real release

### DIFF
--- a/msmbuilder/meta.yaml
+++ b/msmbuilder/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: !!str 3.0.0
 
 source:
-    git_url: git@github.com:msmbuilder/msmbuilder.git
+    git_url: https://github.com/msmbuilder/msmbuilder.git
     git_tag: v3.0.0
 
 build:

--- a/msmbuilder/meta.yaml
+++ b/msmbuilder/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: msmbuilder
-  version: 3.0b1
+  version: !!str 3.0.0
 
 source:
-  fn: master.zip
-  url: https://github.com/msmbuilder/msmbuilder/archive/master.zip
+    git_url: git@github.com:msmbuilder/msmbuilder.git
+    git_tag: v3.0.0
 
 build:
   preserve_egg_dir: True
@@ -17,7 +17,7 @@ requirements:
   build:
     - python
     - setuptools
-    - cython    
+    - cython
     - numpy
     - mdtraj
   run:
@@ -43,8 +43,8 @@ test:
   commands:
     - msmb -h
     - nosetests msmbuilder -v
-  
-  
+
+
 about:
   home: https://github.com/msmbuilder/msmbuilder
   license: LGPLv2.1+


### PR DESCRIPTION
As mentioned [here](https://github.com/omnia-md/conda-recipes/issues/82#issuecomment-69391043), the msmbuilder recipe was simply pulling from the master HEAD.

I made the first "real" 3.0 [release](https://github.com/msmbuilder/msmbuilder/releases/tag/v3.0.0) of msmbuilder on github, and updated this recipe to pull that code.