### PR TITLE
Added travis-ci badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/omnia-md/conda-recipes.svg?branch=master)](https://travis-ci.org/omnia-md/conda-recipes)
+
 conda-recipes
 -------------
 


### PR DESCRIPTION
This just adds a badge to the `README.md` to report on the travis-ci build status.