### PR TITLE
Fix issue with extra files in OpenMM

### DIFF
--- a/openmm/meta.yaml
+++ b/openmm/meta.yaml
@@ -36,4 +36,4 @@ test:
 
 about:
   home: http://openmm.org
-  license: MIT
+  license: LGPL and MIT

--- a/openmm/meta.yaml
+++ b/openmm/meta.yaml
@@ -37,3 +37,4 @@ test:
 about:
   home: http://openmm.org
   license: LGPL and MIT
+  summary: A high performance toolkit for molecular simulation.

--- a/openmm/meta.yaml
+++ b/openmm/meta.yaml
@@ -10,7 +10,8 @@ source:
     - plugin-dir.patch
 
 build:
-  number: 0
+  number: 1
+  preserve_egg_dir: yes
 
 requirements:
   build:

--- a/openmm/meta.yaml
+++ b/openmm/meta.yaml
@@ -27,6 +27,13 @@ requirements:
     - python
     - fftw3f # [not win]
 
+test:
+  imports:
+    - simtk
+    - simtk.openmm
+  commands:
+    - python -m simtk.testInstallation
+
 about:
   home: http://openmm.org
   license: MIT


### PR DESCRIPTION
I'm not 100% sure why this happens. It relates to wierd setuptools stuff like namespace packages. But this does get rid of the extra files from #104.