### PR TITLE
Add swig back into the openmm conda build requirements.

### DIFF
--- a/openmm/meta.yaml
+++ b/openmm/meta.yaml
@@ -21,7 +21,7 @@ requirements:
     - fftw3f # [not win]
     - sphinx
     - sphinxcontrib-bibtex
-    # - swig # leave out unless we use VM with workaround because conda swig is broken
+    - swig
 
   run:
     - python


### PR DESCRIPTION
I think the reason our py33 and py34 builds were failing is that we were using the ancient version of swig provided on the VM.  We have two options:

1.  `conda install swig` every time we provision a new miniconda install.  
2.  Add swig to the openmm `meta.yaml`

I've tested both of these.  Here I've implemented (2), as it's the more elegant solution.  We do have to worry about some of the strange swig path issues that were observed in some previous swig conda packages.  However, I imagine that both (1) and (2) will be affected by this equally, as anaconda seems to have only a single swig package online (swig-3.0.2-0.tar.bz2).  