### PR TITLE
Using nose.attr('slow') to handle slow tests in gaff2xml recipe

### DIFF
--- a/gaff2xml/meta.yaml
+++ b/gaff2xml/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: gaff2xml
-  version: 0.6.0
+  version: 0.6.1
 
 source:
     git_url: https://github.com/choderalab/gaff2xml.git
-    git_tag: 0.6
+    git_tag: 0.6.1
 
 build:
   preserve_egg_dir: True
@@ -39,7 +39,7 @@ test:
   imports:
     - gaff2xml
   commands:
-    - nosetests gaff2xml -v
+    - nosetests gaff2xml -v -a '!slow'
 
 about:
   home: https://github.com/choderalab/gaff2xml

--- a/gaff2xml/meta.yaml
+++ b/gaff2xml/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: gaff2xml
-  version: 0.6.1
+  version: 0.6.2
 
 source:
     git_url: https://github.com/choderalab/gaff2xml.git
-    git_tag: 0.6.1
+    git_tag: 0.6.2
 
 build:
   preserve_egg_dir: True


### PR DESCRIPTION
FYI: I previously had some hard-coded jenkins / travis detection coded into various nosetests.  Now that we're running several different CI frameworks, I think a more generalizable approach is as follows:

1. Tag all slow tests using @attr('slow')
2.  In all conda recipes, disable the slow tests by default (`nosetests -a '!slow'`), so that recipes can be built in a reasonable amount of time
3.  We can leave off the `-a '!slow'` flag when running tests locally 

IMHO this approach will work fairly generally for multiple packages.