### PR TITLE
OpenMM Windows + OPENMM_PLUGIN_DIR

### DIFF
--- a/openmm/bld.bat
+++ b/openmm/bld.bat
@@ -1,14 +1,10 @@
-:: Only python 3, since python2 uses VS2008,
-:: which is not capable of compiling OpenMM
-"%PYTHON%" -c "import sys; assert sys.version_info[0] == 3"
-if errorlevel 1 exit 1
-
+:: Use python version to select which Visual Studio to use
+:: For win-64, we'll need more, since those are separate compilers
 :: Build in subdirectory.
 mkdir build
 cd build
-cmake -DCMAKE_INSTALL_PREFIX=%PREFIX% ..
-msbuild ALL_BUILD.vcxproj
-msbuild INSTALL.vcxproj
+cmake -G "NMake Makefiles" -DCMAKE_INSTALL_PREFIX=%PREFIX% -DCMAKE_BUILD_TYPE=Release ..
+jom install
 
 set OPENMM_INCLUDE_PATH=%PREFIX%\include
 set OPENMM_LIB_PATH=%PREFIX%\lib

--- a/openmm/meta.yaml
+++ b/openmm/meta.yaml
@@ -3,10 +3,8 @@ package:
   version: 6.3.dev0
 
 source:
-  # url: https://github.com/pandegroup/openmm/archive/6.2.tar.gz
-  # fn: 6.2.tar.gz
-  git_url: https://github.com/rmcgibbo/openmm
-  git_tag: win32
+  url: https://github.com/pandegroup/openmm/archive/6.2.tar.gz
+  fn: 6.2.tar.gz
 
 build:
   number: 1

--- a/openmm/meta.yaml
+++ b/openmm/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - fftw3f # [not win]
     - sphinx
     - sphinxcontrib-bibtex
-    - swig
+    - swig   # [not win]
 
   run:
     - python

--- a/openmm/openmm-pr-780.patch
+++ b/openmm/openmm-pr-780.patch
@@ -1,0 +1,28 @@
+diff --git wrappers/python/simtk/openmm/__init__.py wrappers/python/simtk/openmm/__init__.py
+index 7e47b11..3092e3e 100644
+--- wrappers/python/simtk/openmm/__init__.py
++++ wrappers/python/simtk/openmm/__init__.py
+@@ -10,11 +10,22 @@ It also tries to load any plugin modules it can find.
+ __author__ = "Randall J. Radmer"
+
+ import os, os.path
++import sys
++from simtk.openmm import version
++
++if sys.platform == 'win32':
++    _path = os.environ['PATH']
++    os.environ['PATH'] += '%(lib)s;%(lib)s\plugins' % {'lib': version.openmm_library_path}
++
+ from simtk.openmm.openmm import *
+ from simtk.openmm.vec3 import Vec3
+-from simtk.openmm import version
++
+ if os.getenv('OPENMM_PLUGIN_DIR') is None and os.path.isdir(version.openmm_library_path):
+     pluginLoadedLibNames = Platform.loadPluginsFromDirectory(os.path.join(version.openmm_library_path, 'plugins'))
+ else:
+     pluginLoadedLibNames = Platform.loadPluginsFromDirectory(Platform.getDefaultPluginsDirectory())
++
++if sys.platform == 'win32':
++    os.environ['PATH'] = _path
++    del _path
+ __version__ = Platform.getOpenMMVersion()

--- a/openmm/openmm-pr-780.patch
+++ b/openmm/openmm-pr-780.patch
@@ -11,7 +11,7 @@ index 7e47b11..3092e3e 100644
 +
 +if sys.platform == 'win32':
 +    _path = os.environ['PATH']
-+    os.environ['PATH'] += '%(lib)s;%(lib)s\plugins' % {'lib': version.openmm_library_path}
++    os.environ['PATH'] = '%(lib)s;%(lib)s\plugins;%(path)s' % {'lib': version.openmm_library_path, 'path': _path}
 +
  from simtk.openmm.openmm import *
  from simtk.openmm.vec3 import Vec3

--- a/openmm/post-link.bat
+++ b/openmm/post-link.bat
@@ -1,0 +1,1 @@
+%PREFIX%\python -c "import os, os.path, simtk; dir = os.path.dirname(simtk.__file__); fn = os.path.join(dir, 'openmm', 'version.py'); f = open(fn, 'a'); f.write('\nopenmm_library_path = \"{}\\\\lib\"'.format(os.environ['PREFIX'].replace('\\','\\\\'))); f.close()"

--- a/openmm/post-link.sh
+++ b/openmm/post-link.sh
@@ -19,7 +19,15 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
             fi
        done
     done
-
-
 fi
 
+cat <<EOF > _temp.py
+import os.path
+import simtk
+dir = os.path.dirname(simtk.__file__)
+fn = os.path.join(dir, 'openmm', 'version.py')
+f = open(fn, 'a')
+f.write("\nopenmm_library_path = '%s/lib'\n" % os.environ['PREFIX'])
+EOF
+$PREFIX/bin/python _temp.py
+rm _temp.py


### PR DESCRIPTION
Changes to the OpenMM recipe, bumping the build number to 2. This should ensure that the [setting of environment variables](http://docs.openmm.org/6.2.0/userguide/application.html#installing-on-windows) like the PATH or OPENMM_PLUGIN_DIR is not required on *nix or windows when installing via conda.

To do this, https://github.com/pandegroup/openmm/pull/780 is incorporated as a patch file. There is also a really horrendous post-link.(bat|sh) that modifies `site-packages/simtk/openmm/version.py` when the conda package is being so that `__init__.py` knows where to find the openmm libraries.

I'll do the merge. I still need to do more testing on windows.