### PR TITLE
Added mpi4py and pyyaml to requirements for yank.

### DIFF
--- a/yank/meta.yaml
+++ b/yank/meta.yaml
@@ -25,7 +25,6 @@ requirements:
     - docopt
     - gaff2xml
     - jinja2
-    - mpi4py
 
   run:
     - python

--- a/yank/meta.yaml
+++ b/yank/meta.yaml
@@ -25,6 +25,7 @@ requirements:
     - docopt
     - gaff2xml
     - jinja2
+    - mpi4py
 
   run:
     - python
@@ -39,8 +40,9 @@ requirements:
     - ambermini
     - docopt
     - gaff2xml
-#    - pyaml
-    - jinja2    
+    - mpi4py
+    - pyyaml
+    - jinja2
 
 test:
   requires:
@@ -50,7 +52,7 @@ test:
   commands:
     - nosetests yank --nocapture --verbosity=2
     - which yank
-    - yank --help    
+    - yank --help
 
 about:
   home: https://github.com/choderalab/yank


### PR DESCRIPTION
I've added `mpi4py` (necessary if MPI runs are desired) and `pyyaml` (since we'll need it soon anyway).