### PR TITLE
Updated openmmtools recipe

### DIFF
--- a/openmmtools/meta.yaml
+++ b/openmmtools/meta.yaml
@@ -1,14 +1,14 @@
 package:
   name: openmmtools
-  version: 0.6.1
+  version: 0.6.2
 
 source:
     git_url: https://github.com/choderalab/openmmtools.git
-    git_tag: 0.6.1
+    git_tag: 0.6.2
 
 build:
   preserve_egg_dir: True
-  number: 1
+  number: 0
 
 requirements:
   build:
@@ -28,7 +28,7 @@ requirements:
     - nose
     - setuptools
     - jinja2
-    - six    
+    - six
 
 
 test:


### PR DESCRIPTION
This increments the version number to the new [0.6.2 release](https://github.com/choderalab/openmmtools/releases/tag/0.6.2) and resets the build number to 0.