### PR TITLE
ambermini static

### DIFF
--- a/ambermini/build.sh
+++ b/ambermini/build.sh
@@ -3,6 +3,9 @@
 # Required for cbio cluster for some stupid reason.
 #export LD_LIBRARY_PATH="/opt/gnu/gcc/4.8.1/lib64:/opt/gnu/gcc/4.8.1/lib:/opt/gnu/gmp/lib:/opt/gnu/mpc/lib:/opt/gnu/mpfr/lib"
 
+export CUSTOMBUILDFLAGS="-static-libgfortran /usr/local/Cellar/gcc/4.9.2_1/lib/gcc/4.9/libquadmath.a \
+	  -static-libgcc -lgfortran"
+
 export CFLAGS="-I$PREFIX/include $CFLAGS"
 export LDFLAGS="-L$PREFIX/lib $LDFLAGS"
 

--- a/ambermini/build.sh
+++ b/ambermini/build.sh
@@ -3,8 +3,12 @@
 # Required for cbio cluster for some stupid reason.
 #export LD_LIBRARY_PATH="/opt/gnu/gcc/4.8.1/lib64:/opt/gnu/gcc/4.8.1/lib:/opt/gnu/gmp/lib:/opt/gnu/mpc/lib:/opt/gnu/mpfr/lib"
 
-export CUSTOMBUILDFLAGS="-static-libgfortran /usr/local/Cellar/gcc/4.9.2_1/lib/gcc/4.9/libquadmath.a \
-	  -static-libgcc -lgfortran"
+# See https://github.com/omnia-md/conda-recipes/pull/134
+#     https://github.com/omnia-md/conda-recipes/issues/132
+# This may require a patched version of gfortran to properly produce staticly linked binaries on osx
+if [[ "$OSTYPE" == "darwin"* ]]; then
+   export CUSTOMBUILDFLAGS="-static-libgfortran /usr/local/Cellar/gcc/4.9.2_1/lib/gcc/4.9/libquadmath.a -static-libgcc -lgfortran"
+fi
 
 export CFLAGS="-I$PREFIX/include $CFLAGS"
 export LDFLAGS="-L$PREFIX/lib $LDFLAGS"

--- a/ambermini/meta.yaml
+++ b/ambermini/meta.yaml
@@ -7,6 +7,9 @@ source:
   url: https://github.com/choderalab/ambermini/archive/v.14.0.1.zip
   md5: 4653df08b0f9d94a39704c10591fcd84
 
+build:
+  number: 1
+
 requirements:
   build:
     - zlib


### PR DESCRIPTION
So this change, on my machine where I've trashed the file `libquadmath.0.dylib` from my homebrewed-gfortran, which causes the linker to statically link to libquadmath, produces a static build.

I can upload the binary to binstar.