### PR TITLE
Updated yank recipe to also install examples

### DIFF
--- a/yank/build.sh
+++ b/yank/build.sh
@@ -1,1 +1,9 @@
-python setup.py install
+#!/bin/bash
+
+cp -r $RECIPE_DIR/../.. $SRC_DIR
+$PYTHON setup.py clean
+$PYTHON setup.py install
+
+# Push examples to anaconda/share/yank/examples/
+mkdir $PREFIX/share/yank
+cp -r $RECIPE_DIR/../../examples $PREFIX/share/yank/

--- a/yank/meta.yaml
+++ b/yank/meta.yaml
@@ -8,7 +8,7 @@ source:
 
 build:
   preserve_egg_dir: True
-  number: 1
+  number: 2
 
 requirements:
   build:
@@ -42,7 +42,7 @@ requirements:
     - mpi4py
     - pyyaml
     - jinja2
-    - clusterutils    
+    - clusterutils
 
 test:
   requires:


### PR DESCRIPTION
This version installs examples into `anaconda/share/yank/examples/` to match https://github.com/choderalab/yank/pull/209.