### PR TITLE
Don't display progress bar in conda-build-all

### DIFF
--- a/conda-build-all
+++ b/conda-build-all
@@ -209,7 +209,7 @@ def execute(args, p):
                                           binstar_handle=binstar):
                     continue
 
-                cmd = ['conda-build', '--python', python, '--numpy', numpy]
+                cmd = ['conda-build', '-q', '--python', python, '--numpy', numpy]
                 if args.notest:
                     cmd.append('--no-test')
                 cmd.append(recipe)


### PR DESCRIPTION
If you look at one of the jenkins console logs, a lot of the output is taken up by the progress bar streaming down the screen. Kind of annoying. This gets rid of it.

https://jenkins.choderalab.org/job/conda-omnia-release-linux-vagrant/54/console