### PR TITLE
added conda recipe for svgwrite

### DIFF
--- a/svgwrite/bld.bat
+++ b/svgwrite/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/svgwrite/build.sh
+++ b/svgwrite/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/svgwrite/meta.yaml
+++ b/svgwrite/meta.yaml
@@ -1,0 +1,62 @@
+package:
+  name: svgwrite
+  version: !!str 1.1.6
+
+source:
+  fn: svgwrite-1.1.6.tar.gz
+  url: https://pypi.python.org/packages/source/s/svgwrite/svgwrite-1.1.6.tar.gz
+  md5: 0d54ccf5584dd1f98fe22b7ac172bef1
+#  patches:
+   # List any patch files here
+   # - fix.patch
+
+# build:
+  # preserve_egg_dir: True
+  # entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - svgwrite = svgwrite:main
+    #
+    # Would create an entry point called svgwrite that calls svgwrite.main()
+
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - pyparsing >=2.0.1
+
+  run:
+    - python
+    - pyparsing >=2.0.1
+
+test:
+  # Python imports
+  imports:
+    - svgwrite
+
+  # commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+
+
+  # You can also put a file called run_test.py in the recipe that will be run
+  # at test time.
+
+  # requires:
+    # Put any additional test requirements here.  For example
+    # - nose
+
+about:
+  home: http://bitbucket.org/mozman/svgwrite
+  license: MIT License
+  summary: 'A Python library to create SVG drawings.'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml


### PR DESCRIPTION
added svgwrite to replace pip install svgwrite for `openpathsampling`

A build package has already been added to `binstar/omnia`

The recipe was built using `conda skeleton` but I had to remove the `svgwrite/data` import for testing.
The package seems to load correctly.