### PR TITLE
Updated openmm-dev recipe to use 10.7 SDK on osx builds.

### DIFF
--- a/openmm-dev/build.sh
+++ b/openmm-dev/build.sh
@@ -14,8 +14,8 @@ if [[ "$OSTYPE" == "linux-gnu" ]]; then
     CMAKE_FLAGS+=" -DCUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda-6.5"
 elif [[ "$OSTYPE" == "darwin"* ]]; then
     CMAKE_FLAGS+=" -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++"
-    CMAKE_FLAGS+=" -DCMAKE_OSX_DEPLOYMENT_TARGET=10.9"
-    CMAKE_FLAGS+=" -DCMAKE_OSX_SYSROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.9.sdk"
+    CMAKE_FLAGS+=" -DCMAKE_OSX_DEPLOYMENT_TARGET=10.7"
+    CMAKE_FLAGS+=" -DCMAKE_OSX_SYSROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.7.sdk"
     CMAKE_FLAGS+=" -DOPENMM_BUILD_OPENCL_LIB=OFF -DOPENMM_BUILD_DRUDE_OPENCL_LIB=OFF -DOPENMM_BUILD_RPMD_OPENCL_LIB=OFF -DOPENMM_BUILD_OPENCL_TESTS=FALSE -DOPENMM_BUILD_OPENCL_DOUBLE_PRECISION_TESTS=FALSE" # Don't build OpenCL on OS X
 fi
 

--- a/openmm-dev/meta.yaml
+++ b/openmm-dev/meta.yaml
@@ -12,7 +12,7 @@ source:
     #- openmm-pr-780.patch
 
 build:
-  number: 0
+  number: 1
   preserve_egg_dir: yes
 
 requirements:


### PR DESCRIPTION
This replicates the fix from #176 for `openmm-dev`