### PR TITLE
Enable 64-bit python builds in Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,11 @@ environment:
       PYTHON_ARCH: "32"
       CONDA_PY: "27"
       CONDA_NPY: "19"
+    - PYTHON: "C:\\Python27_64"
+      PYTHON_VERSION: "2.7"
+      PYTHON_ARCH: "64"
+      CONDA_PY: "27"
+      CONDA_NPY: "19"
 
 install:
   # this installs the appropriate Miniconda (Py2/Py3, 32/64 bit),


### PR DESCRIPTION
I'm trying this one step at a time.