### PR TITLE
Update openmoltools meta.yaml for 0.6.7 release

### DIFF
--- a/openmoltools/meta.yaml
+++ b/openmoltools/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: openmoltools
-  version: 0.6.6
+  version: 0.6.7
 
 source:
     git_url: https://github.com/choderalab/openmoltools.git
-    git_tag: v0.6.6
+    git_tag: v0.6.7
 
 
 build:


### PR DESCRIPTION
0.6.7 release adds some GROMACS support to openmoltools, as well as fixing some issues with error checking of AMBER tools and reorganization of AMBER-related functionality.