### PR TITLE
Update requirements to work around MDTraj bug

### DIFF
--- a/openmoltools/meta.yaml
+++ b/openmoltools/meta.yaml
@@ -21,6 +21,7 @@ requirements:
     - pandas    
     - openmm
     - ambermini
+    - pytables
 #    - rdkit    # rdkit is an optional dependency, may want to comment this out for the release version.
   run:
     - python
@@ -32,6 +33,7 @@ requirements:
     - scipy
     - openmm
     - ambermini
+    - pytables
 #    - rdkit    # rdkit is an optional dependency, may want to comment this out for the release version.
 
 test:


### PR DESCRIPTION
As per https://github.com/mdtraj/mdtraj/issues/852, mdtraj 1.4.0 had an issue when `tables` is not installed. Updating requirements to require `tables` to avoid this problem.