### PR TITLE
[pymbar] Updated to 3.0.0.beta2

### DIFF
--- a/pymbar/meta.yaml
+++ b/pymbar/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: pymbar
-  version: 3.0.0.beta1
+  version: 3.0.0.beta2
 
 source:
-  url: https://github.com/choderalab/pymbar/archive/3.0.0.beta1.tar.gz
-  fn: 3.0.0.beta1.tar.gz
+  url: https://github.com/choderalab/pymbar/archive/3.0.0.beta2.tar.gz
+  fn: 3.0.0.beta2.tar.gz
 
 build:
   preserve_egg_dir: True


### PR DESCRIPTION
This updates pymbar to 3.0.0.beta2 to fix some failing win conda package builds.