### PR TITLE
Update openmoltools for 0.6.8 point release

### DIFF
--- a/openmoltools/meta.yaml
+++ b/openmoltools/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: openmoltools
-  version: 0.6.7
+  version: 0.6.8
 
 source:
     git_url: https://github.com/choderalab/openmoltools.git
-    git_tag: v0.6.7
+    git_tag: v0.6.8
 
 
 build:


### PR DESCRIPTION
This point release is needed for ParmEd 2.0 compatibility, among other things.