### PR TITLE
Fix openmoltools conda recipe to add parmed

### DIFF
--- a/openmoltools/meta.yaml
+++ b/openmoltools/meta.yaml
@@ -21,6 +21,7 @@ requirements:
     - pandas    
     - openmm
     - ambermini
+    - parmed
 #    - rdkit    # rdkit is an optional dependency, may want to comment this out for the release version.
   run:
     - python
@@ -32,6 +33,7 @@ requirements:
     - scipy
     - openmm
     - ambermini
+    - parmed
 #    - rdkit    # rdkit is an optional dependency, may want to comment this out for the release version.
 
 test:


### PR DESCRIPTION
@jchodera - looks like @kylebeauchamp forgot to add parmed as a requirement in the omnia conda recipe when he added it as a requirement for travis in the package itself, hence the problem here. It's not clear to me why this didn't cause problems sooner, since `utils` has been trying to import `parmed` for a while.