### PR TITLE
[openmoltools] openmm-dev is required until OpenMM 6.3 is released

### DIFF
--- a/openmoltools/meta.yaml
+++ b/openmoltools/meta.yaml
@@ -18,8 +18,8 @@ requirements:
     - mdtraj
     - numpy
     - scipy
-    - pandas    
-    - openmm
+    - pandas
+    - openmm-dev
     - ambermini
     - parmed
 #    - rdkit    # rdkit is an optional dependency, may want to comment this out for the release version.
@@ -31,7 +31,7 @@ requirements:
     - mdtraj
     - numpydoc
     - scipy
-    - openmm
+    - openmm-dev
     - ambermini
     - parmed
 #    - rdkit    # rdkit is an optional dependency, may want to comment this out for the release version.

--- a/openmoltools/meta.yaml
+++ b/openmoltools/meta.yaml
@@ -9,7 +9,7 @@ source:
 
 build:
   preserve_egg_dir: True
-  number: 0
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
See https://github.com/choderalab/openmoltools/pull/126