### PR TITLE
Find the appropriate version of conda_build

### DIFF
--- a/conda-build-all
+++ b/conda-build-all
@@ -13,6 +13,7 @@ import tempfile
 from subprocess import check_output, call, check_call, CalledProcessError
 from functools import reduce
 from six import string_types
+from distutils.spawn import find_executable
 
 BINSTAR_TOKEN = os.environ.pop('BINSTAR_TOKEN', None)
 
@@ -34,6 +35,17 @@ except ImportError:
     print('This script requires binstar', file=sys.stderr)
     print('  $ conda install binstar')
     exit(1)
+
+ROOTDIR = os.path.dirname(sys.executable)
+if sys.platform == 'win32':
+	# find conda-build associated with the current python
+	# interpreter
+	conda_build = find_executable('conda-build',
+		path=ROOTDIR + ';' + ROOTDIR + '\Scripts')
+	assert conda_build is not None
+else:
+	conda_build = find_executable('conda-build', path=ROOTDIR)
+	assert conda_build is not None
 
 
 def main():
@@ -143,7 +155,7 @@ def sort_recipes(recipe_paths):
 @memoized
 def conda_build_output(recipe_path, python, numpy):
     out = check_output(
-        ['conda-build', '--output', '--python', python,
+        [conda_build, '--output', '--python', python,
          '--numpy', numpy, recipe_path]).strip()
     return out.decode('utf-8')
 
@@ -278,7 +290,7 @@ def execute(args, p):
                                               binstar_handle=binstar):
                         continue
 
-                    cmd = ['conda-build', '-q', '--python', python, '--numpy', numpy, '--quiet']
+                    cmd = [conda_build, '-q', '--python', python, '--numpy', numpy, '--quiet']
                     if args.notest:
                         cmd.append('--no-test')
                     cmd.append(recipe)


### PR DESCRIPTION
Modifies `conda-build-all` to find conda_build not by taking the first thing in the path, but by looking adjacent to the python interpreter used to invoke the script. The reason for this is, on windows, that I have both a 64-bit and 32-bit conda installed. Only the 64-bit interpreter is in my `PATH`. This way, I can do `C:\Path\To\32\bit\python.exe conda-build-all <packages>`, and it will invoke the correct copy of conda_build (the 32-bit one), even though it's not in my path.