### PR TITLE
Revert "No jinja2/markupsafe on appveyor?"

### DIFF
--- a/devtools/appveyor/install.ps1
+++ b/devtools/appveyor/install.ps1
@@ -136,7 +136,7 @@ function InstallMissingHeaders () {
 function main () {
     InstallMiniconda $env:PYTHON_VERSION $env:PYTHON_ARCH $env:PYTHON
     UpdateConda $env:PYTHON
-    InstallCondaPackages $env:PYTHON "conda-build pip anaconda-client six"
+    InstallCondaPackages $env:PYTHON "conda-build pip jinja2 anaconda-client six"
     InstallMissingHeaders
 }
 


### PR DESCRIPTION
Latest release of conda-build (1.17.0) fixes the root cause of #242 upstream, so uninstalling jinja2 should not be necessary.

This reverts commit 2ed5a3e6ffd71644e90443714774b80a7e1c744a.