### PR TITLE
Disable full MSMBuilder test suite in conda-recipes

### DIFF
--- a/msmbuilder/meta.yaml
+++ b/msmbuilder/meta.yaml
@@ -43,7 +43,7 @@ test:
     - msmbuilder
   commands:
     - msmb -h
-    - nosetests msmbuilder -v
+    - # nosetests msmbuilder -v
 
 
 about:


### PR DESCRIPTION
Not all of the test suite dependencies are installed, and it takes a long time.