### PR TITLE
Update for openmoltools 0.6.9 / standard requirements

### DIFF
--- a/openmoltools/meta.yaml
+++ b/openmoltools/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: openmoltools
-  version: 0.6.8
+  version: 0.6.9
 
 source:
     git_url: https://github.com/choderalab/openmoltools.git
-    git_tag: v0.6.8
+    git_tag: v0.6.9
 
 
 build:
@@ -15,12 +15,16 @@ requirements:
   build:
     - python
     - setuptools
+    - pandas
+    - six
     - mdtraj
     - numpy
+    - numpydoc
     - scipy
     - pandas
     - openmm
     - ambermini
+    - pytables
     - parmed
 #    - rdkit    # rdkit is an optional dependency, may want to comment this out for the release version.
   run:
@@ -29,10 +33,12 @@ requirements:
     - pandas
     - six
     - mdtraj
+    - numpy
     - numpydoc
     - scipy
     - openmm
     - ambermini
+    - pytables
     - parmed
 #    - rdkit    # rdkit is an optional dependency, may want to comment this out for the release version.
 


### PR DESCRIPTION
Updating for new 0.6.9 release of openmoltools.

Additionally, standardizing run/build requirements with those within the project itself.