### PR TITLE
Arpack

### DIFF
--- a/arpack/Makefile
+++ b/arpack/Makefile
@@ -1,6 +1,7 @@
 F2C      = f2c
-F2CFLAGS = -ARw8 -Nn802 -Nq300 -Nx400
-CC     	 = cc
+F2CFLAGS = -ARw8 -Nn802 -Nq300 -Nx400 -w
+CC       = cc
+AR       = ar
 
 PREFIX := $(shell echo $(PREFIX))
 CFLAGS := -O3 -fPIC -I$(PREFIX)/include
@@ -19,6 +20,10 @@ OBJ   := $(patsubst %.f,%.o,$(F_SRC))
 
 libarpack.so: $(OBJ)
 	$(CC)  -shared -o $@ $(OBJ) $(F2C_LDFLAGS) $(LDFLAGS)
+
+libarpack.a: $(OBJ)
+	$(AR) rcs $@ $(OBJ)
+	ranlib $@
 
 clean:
 	rm -f UTIL/*.c UTIL/*.o SRC/*.c SRC/*.o

--- a/arpack/Makefile
+++ b/arpack/Makefile
@@ -1,0 +1,24 @@
+F2C      = f2c
+F2CFLAGS = -ARw8 -Nn802 -Nq300 -Nx400
+CC     	 = cc
+
+PREFIX := $(shell echo $(PREFIX))
+CFLAGS := -O3 -fPIC -I$(PREFIX)/include
+F2C_LDFLAGS = -L$(PREFIX)/lib -lf2c
+LDFLAGS = -lblas -llapack
+
+F_SRC := $(wildcard SRC/*.f) $(wildcard UTIL/*.f)
+C_SRC := $(patsubst %.f,%.c,$(F_SRC))
+OBJ   := $(patsubst %.f,%.o,$(F_SRC))
+
+%.c : %.f
+	(cd $(dir $<) && f2c $(F2CFLAGS) $(notdir $<))
+
+%.o : %.c
+	$(CC) $(CFLAGS) -c $< -o $@
+
+libarpack.so: $(OBJ)
+	$(CC)  -shared -o $@ $(OBJ) $(F2C_LDFLAGS) $(LDFLAGS)
+
+clean:
+	rm -f UTIL/*.c UTIL/*.o SRC/*.c SRC/*.o

--- a/arpack/build.sh
+++ b/arpack/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 rm UTIL/second.f
-make -f $RECIPE_DIR/Makefile -r -j$CPU_COUNT libarpack.so
+make -f $RECIPE_DIR/Makefile -r -j$CPU_COUNT libarpack.a libarpack.so
 cp libarpack.so $PREFIX/lib/
-
+cp libarpack.a $PREFIX/lib/

--- a/arpack/build.sh
+++ b/arpack/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+rm UTIL/second.f
+make -f $RECIPE_DIR/Makefile -r -j$CPU_COUNT libarpack.so
+cp libarpack.so $PREFIX/lib/
+

--- a/arpack/meta.yaml
+++ b/arpack/meta.yaml
@@ -1,0 +1,17 @@
+package:
+  name: arpack
+  version: "3.2.0"
+
+source:
+  url: https://github.com/opencollab/arpack-ng/archive/3.2.0.tar.gz
+  fn: 3.2.0.tar.gz
+  md5: 0ae8a0bb796370b06647d9e005c0f3ea
+
+requirements:
+  build:
+    - f2c
+
+about:
+  home: https://github.com/opencollab/arpack-ng
+  license:
+  summary: "ARPACK is a collection of Fortran77 subroutines designed to solve large scale eigenvalue problems."

--- a/f2c/build.sh
+++ b/f2c/build.sh
@@ -1,0 +1,19 @@
+mkdir -p $PREFIX/bin
+mkdir -p $PREFIX/include
+mkdir -p $PREFIX/lib
+
+curl http://www.netlib.org/f2c/src/makefile.u -o src/Makefile
+(cd src && make -j$CPU_COUNT)
+
+cp src/f2c $PREFIX/bin
+cp f2c.h   $PREFIX/include
+
+
+curl http://archive.ubuntu.com/ubuntu/pool/universe/libf/libf2c2/libf2c2_20090411.orig.tar.gz -o libf2c2_20090411.orig.tar.gz
+tar -xzvf libf2c2_20090411.orig.tar.gz
+cd libf2c2-20090411.orig
+
+sed 's/CFLAGS = -O/CFLAGS = -O3 -fPIC/' makefile.u > Makefile
+make -j$CPU_COUNT
+
+cp libf2c.a $PREFIX/lib/libf2c.a

--- a/f2c/meta.yaml
+++ b/f2c/meta.yaml
@@ -1,0 +1,13 @@
+package:
+  name: f2c
+  version: "20100827"
+
+source:
+  url: http://archive.ubuntu.com/ubuntu/pool/universe/f/f2c/f2c_20100827.orig.tar.gz
+  fn: f2c_20100827.orig.tar.gz
+  md5: 6ecbe4f85f8bb2499fd280dcfd146dd5
+
+about:
+  home: http://netlib.org/f2c/
+  license: BSD
+  summary: 'FORTRAN 77 to C/C++ translator'


### PR DESCRIPTION
@hainm, this builds arpack for OS X and linux without requiring linking against *any* fortran libraries (no libgfortran or libquadmath).