### PR TITLE
[WIP] Ambermini without OS X conda-gcc runtime dependency

### DIFF
--- a/ambermini/build.sh
+++ b/ambermini/build.sh
@@ -1,25 +1,12 @@
 #!/bin/bash
-
-# Required for cbio cluster for some stupid reason.
-#export LD_LIBRARY_PATH="/opt/gnu/gcc/4.8.1/lib64:/opt/gnu/gcc/4.8.1/lib:/opt/gnu/gmp/lib:/opt/gnu/mpc/lib:/opt/gnu/mpfr/lib"
-
-# See https://github.com/omnia-md/conda-recipes/pull/134
-#     https://github.com/omnia-md/conda-recipes/issues/132
-# This may require a patched version of gfortran to properly produce staticly linked binaries on osx
-#if [[ "$OSTYPE" == "darwin"* ]]; then
-#   cp /opt/local/lib/gcc48/libquadmath.a $PREFIX/lib
-#   export CUSTOMBUILDFLAGS="-static-libgfortran $PREFIX/lib/libquadmath.a -static-libgcc -lgfortran"
-#fi
-
-export CFLAGS="-I$PREFIX/include $CFLAGS"
-export LDFLAGS="-L$PREFIX/lib $LDFLAGS"
+export LDFLAGS="-static-libgcc $PREFIX/lib/libgfortran.a $PREFIX/lib/libquadmath.a"
 
 # Configure build
 chmod u+x configure
 ./configure --prefix=$PREFIX
 
 # Build and install.
-make
+make -j$CPU_COUNT
 chmod -R u+x bin
 make install
 

--- a/ambermini/build.sh
+++ b/ambermini/build.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
-export LDFLAGS="-static-libgcc $PREFIX/lib/libgfortran.a $PREFIX/lib/libquadmath.a"
+export LDFLAGS="-static-libgcc \
+   $(gfortran -print-file-name=libgfortran.a) \
+   $(gfortran -print-file-name=libquadmath.a)"
 
 # Configure build
 chmod u+x configure

--- a/ambermini/build.sh
+++ b/ambermini/build.sh
@@ -7,6 +7,15 @@ export LDFLAGS="-static-libgcc -lm \
 chmod u+x configure
 ./configure --prefix=$PREFIX
 
+# we deal with lgfortran through ldflags. don't want it
+# on config.h, where it overrides and leads to dynamic
+# linking on linux
+if [ "$(uname)" == "Darwin" ]; then
+    sed -i '' 's/-lgfortran//g' config.h
+elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
+    sed -i 's/-lgfortran//g' config.h
+fi
+
 # Build and install.
 make -j$CPU_COUNT
 chmod -R u+x bin

--- a/ambermini/build.sh
+++ b/ambermini/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-export LDFLAGS="-static-libgcc \
+export LDFLAGS="-static-libgcc -lm \
    $(gfortran -print-file-name=libgfortran.a) \
    $(gfortran -print-file-name=libquadmath.a)"
 
@@ -11,4 +11,3 @@ chmod u+x configure
 make -j$CPU_COUNT
 chmod -R u+x bin
 make install
-

--- a/ambermini/meta.yaml
+++ b/ambermini/meta.yaml
@@ -3,12 +3,14 @@ package:
   version: 15.0.4
 
 source:
-  fn: 15.0.4.zip
-  url: https://github.com/choderalab/ambermini/archive/15.0.4.zip
-  md5: 5c72ad3ff91d05b3e10f7610b2149107
+  #fn: 15.0.4.zip
+  #url: https://github.com/choderalab/ambermini/archive/15.0.4.zip
+  #md5: 5c72ad3ff91d05b3e10f7610b2149107
+  git_url: git@github.com:rmcgibbo/ambermini.git
+  git_tag: 504168751bc0f330db32d17807f2804d1c827977
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:
@@ -17,7 +19,6 @@ requirements:
     - mingwpy  [win]
   run:
     - zlib
-    - gcc      [osx]
 
 test:
   commands:


### PR DESCRIPTION
It took me a little while to figure this out, but I think it's correct now. Here's how to link a fortran binary executable or shared library on OS X without requiring that the user have any fortran-related binaries installed.

At the link step, link with GNU `gcc` and pass `-lm -static-libgcc /path/to/libgfortran.a /path/to/libquadmath.a`. Those paths can come from calling `$ gfortran -print-file-name=libgfortran.a`. `$ gfortran -print-file-name=libquadmath.a`