### PR TITLE
arpack without f2c

### DIFF
--- a/arpack/Makefile
+++ b/arpack/Makefile
@@ -1,11 +1,10 @@
-FC = gfortran
-CC = cc
+FC := gfortran
+CC := cc
 
-FFLAGS := -O3 -fPIC
-LDFLAGS = -lblas -llapack -lm -static-libgcc $(shell $(FC) -print-file-name=libgfortran.a) $(shell $(FC) -print-file-name=libquadmath.a)
-
-F_SRC := $(wildcard SRC/*.f) $(wildcard UTIL/*.f)
-OBJ   := $(patsubst %.f,%.o,$(F_SRC))
+FFLAGS  := -O3 -fPIC
+LDFLAGS := -lblas -llapack -lm -static-libgcc $(shell $(FC) -print-file-name=libgfortran.a) $(shell $(FC) -print-file-name=libquadmath.a)
+F_SRC   := $(wildcard SRC/*.f) $(wildcard UTIL/*.f)
+OBJ     := $(patsubst %.f,%.o,$(F_SRC))
 
 %.o : %.f
 	$(FC) $(FFLAGS) -c $< -o $@

--- a/arpack/Makefile
+++ b/arpack/Makefile
@@ -1,0 +1,17 @@
+FC = gfortran
+CC = cc
+
+FFLAGS := -O3 -fPIC
+LDFLAGS = -lblas -llapack -lm -static-libgcc $(shell $(FC) -print-file-name=libgfortran.a) $(shell $(FC) -print-file-name=libquadmath.a)
+
+F_SRC := $(wildcard SRC/*.f) $(wildcard UTIL/*.f)
+OBJ   := $(patsubst %.f,%.o,$(F_SRC))
+
+%.o : %.f
+	$(FC) $(FFLAGS) -c $< -o $@
+
+libarpack.so: $(OBJ)
+	$(CC)  -shared -o $@ $(OBJ) $(LDFLAGS)
+
+clean:
+	rm -f UTIL/*.c UTIL/*.o SRC/*.c SRC/*.o

--- a/arpack/build.sh
+++ b/arpack/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+rm UTIL/second.f
+make -f $RECIPE_DIR/Makefile -r -j$CPU_COUNT libarpack.so
+cp libarpack.so $PREFIX/lib/

--- a/arpack/meta.yaml
+++ b/arpack/meta.yaml
@@ -1,0 +1,17 @@
+package:
+  name: arpack
+  version: "3.2.0"
+
+source:
+  url: https://github.com/opencollab/arpack-ng/archive/3.2.0.tar.gz
+  fn: 3.2.0.tar.gz
+  md5: 0ae8a0bb796370b06647d9e005c0f3ea
+
+requirements:
+  build:
+    - gcc
+
+about:
+  home: https://github.com/opencollab/arpack-ng
+  license:
+  summary: "ARPACK is a collection of Fortran77 subroutines designed to solve large scale eigenvalue problems."


### PR DESCRIPTION
cc #344, build arpack without f2c, but still does not require clients to link against libgfortran.