### PR TITLE
MSMTools links against numpy C API

### DIFF
--- a/msmtools/meta.yaml
+++ b/msmtools/meta.yaml
@@ -7,15 +7,14 @@ source:
   url: https://github.com/markovmodel/msmtools/archive/v1.1.zip 
 
 build:
-  preserve_egg_dir: True
-  number: 1 # take it binstar - take it!
+  number: 2
 
 requirements:
   build:
     - python
     - setuptools
     - cython >=0.20
-    - numpy >=1.7
+    - numpy x.x
     - scipy 
     - nose
     - six
@@ -23,7 +22,7 @@ requirements:
   run:
     - python
     - setuptools
-    - numpy >=1.7
+    - numpy x.x
     - scipy
     - six
 


### PR DESCRIPTION
Fixes
```
[snip]
  File "__init__.pxd", line 155, in init msmtools.estimation.dense.mle_trev_given_pi (msmtools/estimation/dense/mle_trev_given_pi.c:4431)
ValueError: numpy.dtype has the wrong size, try recompiling
```