### PR TITLE
Fixed RDKit for OS X

### DIFF
--- a/boost/build.sh
+++ b/boost/build.sh
@@ -29,7 +29,7 @@ if [[ ( ! -d "${PY_LIB}/config" ) && ( -d "${PY_LIB}/config-${PY_VER}m" ) ]]; th
     ln -s "${PY_LIB}/config-${PY_VER}m" "${PY_LIB}/config"
 fi
 
-cxxflags="-I${PREFIX}/include/"
+cxxflags="-fPIC -I${PREFIX}/include/"
 linkflags="-L${PREFIX}/lib/"
 if [[ "$OSTYPE" == "darwin"* ]]; then
     # http://stackoverflow.com/questions/20108407/how-do-i-compile-boost-for-os-x-64b-platforms-with-stdlibc

--- a/boost/meta.yaml
+++ b/boost/meta.yaml
@@ -8,7 +8,7 @@ source:
    md5: 6aa9a5c6a4ca1016edd0ed1178e3cb87
 
 build:
-  number: 0
+  number: 1
   skip:
     - [win]
 

--- a/rdkit/build.sh
+++ b/rdkit/build.sh
@@ -20,9 +20,12 @@ cmake \
     -D PYTHON_INCLUDE_DIR=${PY_INC} \
     -D PYTHON_NUMPY_INCLUDE_PATH=$SP_DIR/numpy/core/include \
     -D BOOST_ROOT=$PREFIX -D Boost_NO_SYSTEM_PATHS=ON \
+    -D Boost_PYTHON3_LIBRARY_RELEASE=$PREFIX/lib/libboost_python3.a \
+    -D Boost_REGEX_LIBRARY_RELEASE=$PREFIX/lib/libboost_regex.a \
+    -D Boost_SERIALIZATION_LIBRARY_RELEASE=$PREFIX/lib/libboost_serialization.a \
+    -D Boost_SYSTEM_LIBRARY_RELEASE=$PREFIX/lib/libboost_system.a \
+    -D Boost_THREAD_LIBRARY_RELEASE=$PREFIX/lib/libboost_thread.a \
     -D CMAKE_BUILD_TYPE=Release \
     .
 
-make -j $CPU_COUNT
-
-make install
+make -j$CPU_COUNT install

--- a/rdkit/build.sh
+++ b/rdkit/build.sh
@@ -20,6 +20,7 @@ cmake \
     -D PYTHON_INCLUDE_DIR=${PY_INC} \
     -D PYTHON_NUMPY_INCLUDE_PATH=$SP_DIR/numpy/core/include \
     -D BOOST_ROOT=$PREFIX -D Boost_NO_SYSTEM_PATHS=ON \
+    -D Boost_PYTHON_LIBRARY_RELEASE=$PREFIX/lib/libboost_python.a \
     -D Boost_PYTHON3_LIBRARY_RELEASE=$PREFIX/lib/libboost_python3.a \
     -D Boost_REGEX_LIBRARY_RELEASE=$PREFIX/lib/libboost_regex.a \
     -D Boost_SERIALIZATION_LIBRARY_RELEASE=$PREFIX/lib/libboost_serialization.a \

--- a/rdkit/meta.yaml
+++ b/rdkit/meta.yaml
@@ -32,6 +32,20 @@ requirements:
 test:
   imports:
     - rdkit
+    - rdkit.Avalon
+    - rdkit.Dbase
+    - rdkit.ML
+    - rdkit.RDPaths
+    - rdkit.VLib
+    - rdkit.Chem
+    - rdkit.DistanceGeometry
+    - rdkit.Numerics
+    - rdkit.RDRandom
+    - rdkit.DataManip
+    - rdkit.ForceField
+    - rdkit.RDConfig
+    - rdkit.DataStructs
+    - rdkit.Geometry
 
 about:
   home: http://rdkit.org

--- a/rdkit/meta.yaml
+++ b/rdkit/meta.yaml
@@ -3,16 +3,17 @@ package:
   version: 2015.09.1
 
 source:
-  git_url: https://github.com/rdkit/rdkit.git
-  git_tag: Release_2015_09_1
+  url: https://github.com/rdkit/rdkit/archive/Release_2015_09_1.tar.gz
+  fn:  Release_2015_09_1.tar.gz
+  md5: 622f1dd6618cf87cb8003765f90cea8c
   patches:
     - rdpaths.patch
     - rdconfig.patch [win]
 
 build:
-  number: 0 
+  number: 1
   skip:
-    - [osx or win]
+    - [win]
 
 requirements:
   build:
@@ -25,7 +26,6 @@ requirements:
     - freetype
     - py2cairo [linux and py2k]
   run:
-    - boost
     - python
     - numpy
 


### PR DESCRIPTION
Statically linking to boost seems to fix the OS X issue, but it will also be much easier from a compatibility perspective.