### PR TITLE
Release msmbuilder 3.3.1

### DIFF
--- a/msmbuilder/meta.yaml
+++ b/msmbuilder/meta.yaml
@@ -1,14 +1,14 @@
 package:
   name: msmbuilder
-  version: !!str 3.3.0
+  version: "3.3.1"
 
 source:
-    fn: msmbuilder-3.3.0.tar.gz
-    url: https://pypi.python.org/packages/source/m/msmbuilder/msmbuilder-3.3.0.tar.gz#md5=95b458908e53c65e0c0560398a412389
-    md5: 95b458908e53c65e0c0560398a412389
+    fn: msmbuilder-3.3.1.tar.gz
+    url: https://pypi.python.org/packages/source/m/msmbuilder/msmbuilder-3.3.1.tar.gz#md5=fd406242ada2f9007fc60e6607a38956
+    md5: fd406242ada2f9007fc60e6607a38956
 
 build:
-  number: 2
+  number: 0
   entry_points:
     - msmb = msmbuilder.scripts.msmb:main
 
@@ -28,7 +28,7 @@ requirements:
     - pandas
     - six
     - mdtraj
-    - scikit-learn <0.17.0
+    - scikit-learn
     - numpydoc
     - pytables
 
@@ -42,7 +42,6 @@ test:
     - msmbuilder
   commands:
     - msmb -h
-#    - nosetests msmbuilder -v
 
 
 about:


### PR DESCRIPTION
This should actually fix all the sklearn 0.17 issues

https://github.com/msmbuilder/msmbuilder/issues/694
