### PR TITLE
Skip building sphinxcontrib packages on win

### DIFF
--- a/sphinxcontrib-autodoc_doxygen/meta.yaml
+++ b/sphinxcontrib-autodoc_doxygen/meta.yaml
@@ -10,6 +10,8 @@ source:
 build:
   noarch_python: True
   number: 0
+  skip:
+    - [win]
 
 requirements:
   build:

--- a/sphinxcontrib-lunrsearch/meta.yaml
+++ b/sphinxcontrib-lunrsearch/meta.yaml
@@ -9,6 +9,8 @@ source:
 build:
   noarch_python: True
   number: 0
+  skip:
+    - [win]
 
 requirements:
   build:


### PR DESCRIPTION
Apparently, we [can't build `noarch` packages on `win`](https://ci.appveyor.com/project/rmcgibbo/conda-recipes/build/1.0.572/job/fp2wviopka3jae69#L390):
```
[noarch_python] Error: Python noarch packages can currently not be created on Windows systems.
```
This PR skips builds of the new `sphinxcontrib-*` packages on `win`.