### PR TITLE
Add --force flag to conda-build-all

### DIFF
--- a/conda-build-all
+++ b/conda-build-all
@@ -61,6 +61,11 @@ def main():
     p.add_argument('--upload',
         help='Automatically upload to binstar under this username',
     )
+    p.add_argument('--force',
+        action='store_true',
+        dest='force',
+        help='Force a package upload regardless of errors',
+    )
     p.add_argument(
         '--no-test',
         action='store_true',
@@ -200,7 +205,7 @@ def list_package_contents(m, python, numpy):
 
 
 
-def upload_to_binstar(m, python, numpy, username, max_retries=5):
+def upload_to_binstar(m, python, numpy, username, max_retries=5, force=False):
     filename = get_bldpkg_path(m, python, numpy)
     if not os.path.exists(filename):
         print('ERROR: File does not exist: %s' % filename)
@@ -210,6 +215,8 @@ def upload_to_binstar(m, python, numpy, username, max_retries=5):
     if BINSTAR_TOKEN is not None:
         cmd.extend(['-t', BINSTAR_TOKEN])
     cmd.extend(['upload', '--no-progress', '-u', username, filename])
+    if force:
+        cmd.extend(['--force'])
 
     err = None
     for i in range(max_retries):
@@ -290,7 +297,8 @@ def build_package(m, python, numpy, args):
 
     if args.upload is not None:
         if (retcode == 0):
-            upload_to_binstar(m, python, numpy, username=args.upload)
+            upload_to_binstar(m, python, numpy, username=args.upload,
+                              force=args.force)
         else:
             print('Package failed to build (return code %s); will not upload.' % str(retcode))
     sys.stdout.flush()


### PR DESCRIPTION
This adds a `--force` flag to `conda-build-all` to allow us to force uploads to replace existing packages.