### PR TITLE
Upgrade numdifftools to 0.9.14

### DIFF
--- a/numdifftools/meta.yaml
+++ b/numdifftools/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: numdifftools
-  version: !!str 0.9.12
+  version: "0.9.14"
 
 source:
-  fn: numdifftools-0.9.12.zip
-  url: https://pypi.python.org/packages/source/N/Numdifftools/numdifftools-0.9.12.zip
-  md5: f1c3a80a08ca6ca21d7a8966ca5a97b0
+  fn: numdifftools-0.9.14.zip
+  url: https://pypi.python.org/packages/source/N/Numdifftools/numdifftools-0.9.14.zip#md5=04add9a62433466923764d9ef501eeb5
+  md5: 04add9a62433466923764d9ef501eeb5
 
 requirements:
   build:
@@ -13,14 +13,14 @@ requirements:
     - setuptools
     - six
     - pip
-    - numpy >=1.4
-    - scipy >=0.8
+    - numpy
+    - scipy
     - algopy
 
   run:
     - python
-    - numpy >=1.4
-    - scipy >=0.8
+    - numpy
+    - scipy
     - six
     - algopy
 


### PR DESCRIPTION
Current version tries to pull in matplotlib, which is not listed as a dependency.

They changed it so it doesn't import matplotlib at all (yay!) https://github.com/pbrod/numdifftools/commit/79241cd0454b36e057b0ba7424f1a66c607c5228