### PR TITLE
[ambermini and packmol] Update ambermini and packmol builds to fix `GFORTRAN_1.4' not found 

### DIFF
--- a/ambermini/meta.yaml
+++ b/ambermini/meta.yaml
@@ -17,9 +17,11 @@ requirements:
     - bison    [unix]
     - gcc      [unix]
     - mingwpy  [win]
+    - libgfortran ==1.0 [linux]
   run:
     - zlib
     - libgcc   [unix]
+    - libgfortran ==1.0 [linux]
 
 test:
   commands:

--- a/ambermini/meta.yaml
+++ b/ambermini/meta.yaml
@@ -17,11 +17,9 @@ requirements:
     - bison    [unix]
     - gcc      [unix]
     - mingwpy  [win]
-    - libgfortran ==1.0 [linux]
   run:
     - zlib
     - libgcc   [unix]
-    - libgfortran ==1.0 [linux]
 
 test:
   commands:

--- a/ambermini/meta.yaml
+++ b/ambermini/meta.yaml
@@ -8,7 +8,7 @@ source:
   md5: 5c72ad3ff91d05b3e10f7610b2149107
 
 build:
-  number: 3
+  number: 4
 
 requirements:
   build:
@@ -17,9 +17,11 @@ requirements:
     - bison    [unix]
     - gcc      [unix]
     - mingwpy  [win]
+    - libgfortran ==1.0 [linux]
   run:
     - zlib
     - libgcc   [unix]
+    - libgfortran ==1.0 [linux]
 
 test:
   commands:

--- a/packmol/build.sh
+++ b/packmol/build.sh
@@ -3,9 +3,13 @@
 export CFLAGS="-I$PREFIX/include $CFLAGS"
 export LDFLAGS="-L$PREFIX/lib $LDFLAGS"
 
+# Fix broken Makefile.default
+
+sed -e s_/usr/bin/gfortran_AUTO_ Makefile > Makefile.default
+
 # Build and install.
 
-chmod +x configure 
+chmod +x configure
 ./configure
-make
+make parallel
 cp packmol ${PREFIX}/bin/

--- a/packmol/meta.yaml
+++ b/packmol/meta.yaml
@@ -7,7 +7,7 @@ source:
   url: http://www.ime.unicamp.br/~martinez/packmol/packmol.tar.gz
 
 build:
-  number: 2
+  number: 3
 
 requirements:
   build:
@@ -15,9 +15,11 @@ requirements:
     - python
     - mingwpy  [win]
     - gcc      [unix]
+    - libgfortran ==1.0 [linux]
   run:
     - zlib
     - libgcc   [unix]
+    - libgfortran ==1.0 [linux]
 
 test:
   commands:

--- a/packmol/meta.yaml
+++ b/packmol/meta.yaml
@@ -15,11 +15,9 @@ requirements:
     - python
     - mingwpy  [win]
     - gcc      [unix]
-    - libgfortran ==1.0 [linux]
   run:
     - zlib
     - libgcc   [unix]
-    - libgfortran ==1.0 [linux]
 
 test:
   commands:

--- a/packmol/meta.yaml
+++ b/packmol/meta.yaml
@@ -15,9 +15,11 @@ requirements:
     - python
     - mingwpy  [win]
     - gcc      [unix]
+    - libgfortran ==1.0 [linux]
   run:
     - zlib
     - libgcc   [unix]
+    - libgfortran ==1.0 [linux]
 
 test:
   commands:


### PR DESCRIPTION
cc: https://github.com/choderalab/openmoltools/pull/198#issuecomment-192029702