### PR TITLE
Add shiftx2 recipe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ tramp
 
 # AUCTeX auto folder
 /auto/
+
+# vim
+*.swp

--- a/shiftx2/build.sh
+++ b/shiftx2/build.sh
@@ -1,0 +1,10 @@
+make
+mkdir -p $PREFIX/share/ $PREFIX/bin
+cp -r . $PREFIX/share/shiftx2
+cat <<EOF > $PREFIX/bin/shiftx2.py
+#!/usr/bin/env python
+import sys
+import os
+os.environ['PYTHONPATH'] = '$PREFIX/share/shiftx2'
+os.system(' '.join(['/usr/bin/python2', '$PREFIX/share/shiftx2/shiftx2.py'] + sys.argv[1:]))
+EOF

--- a/shiftx2/gcc.patch
+++ b/shiftx2/gcc.patch
@@ -1,0 +1,11 @@
+--- modules/shiftx/Makefile
++++ modules/shiftx/Makefile
+@@ -6,7 +6,7 @@
+ # E-Mail:   anip@redpoll.pharmacy.ualberta.ca
+ #
+ #CC=gcc -Xcpluscomm -cckr
+-CC=/usr/bin/gcc
++CC=gcc
+ CFLAGS=-O3
+ SYSLIB=
+ INCLUDES=-I/usr/include

--- a/shiftx2/meta.yaml
+++ b/shiftx2/meta.yaml
@@ -1,0 +1,32 @@
+package:
+  name: shiftx2
+  version: "1.09A"
+
+source:
+  fn: shiftx2-v109A-linux-20150821.tgz
+  url: http://www.shiftx2.ca/download/shiftx2-v109A-linux-20150821.tgz
+  md5: c425b4fd5b520b517f948ca18af2b19f
+
+build:
+  number: 0
+  skip:
+    - [win]
+
+requirements:
+  build:
+    - python
+  run:
+    - python
+
+test:
+  commands:
+    - shiftx2.py -h
+
+about:
+  home: http://www.shiftx2.ca/
+  license: All rights reserved
+  summary: SHIFTX2 predicts both the backbone and side chain 1H, 13C and 15N
+      chemical shifts for proteins using their structural (PDB) coordinates as
+      input.
+
+# vim: ts=2 sw=2 et

--- a/shiftx2/meta.yaml
+++ b/shiftx2/meta.yaml
@@ -6,6 +6,8 @@ source:
   fn: shiftx2-v109A-linux-20150821.tgz
   url: http://www.shiftx2.ca/download/shiftx2-v109A-linux-20150821.tgz
   md5: c425b4fd5b520b517f948ca18af2b19f
+  patches:
+    - gcc.patch
 
 build:
   number: 0


### PR DESCRIPTION
The full build requires `javac`, which will probably fail here, but the majority of the resulting package works

This is used in mdtraj testing