### PR TITLE
Check if .pre_black_listed is available before trying to open it

### DIFF
--- a/conda-build-all
+++ b/conda-build-all
@@ -318,11 +318,12 @@ def is_prerelease(pkg_meta):
 
 
 def pre_black_listed(pkg_meta):
-    with open('.pre_black_listed') as fh:
-        black_list = fh.read().splitlines()
-        for b in black_list:
-            if pkg_meta.name in b:
-                return True
+    filename = '.pre_black_listed'
+    if os.path.exists(filename):
+        with open(filename) as f:
+            for line in f:
+                if not line.startswith('#') and pkg_meta.name in line:
+                    return True
     return False
 
 def execute(args, p):


### PR DESCRIPTION
#468 broke conda-dev-recipes which didn't have a file called `.pre_black_listed`.