### PR TITLE
Add openmm-example-plugin

### DIFF
--- a/openmm-example-plugin/build.sh
+++ b/openmm-example-plugin/build.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+CMAKE_FLAGS="-DCMAKE_INSTALL_PREFIX=$PREFIX -DBUILD_TESTING=OFF"
+
+CMAKE_FLAGS+=" -DCMAKE_BUILD_TYPE=Release"
+
+if [[ "$OSTYPE" == "linux-gnu" ]]; then
+    CUDA_PATH="/usr/local/cuda-7.5"
+    CMAKE_FLAGS+=" -DCUDA_CUDART_LIBRARY=${CUDA_PATH}/lib64/libcudart.so"
+    CMAKE_FLAGS+=" -DCUDA_NVCC_EXECUTABLE=${CUDA_PATH}/bin/nvcc"
+    CMAKE_FLAGS+=" -DCUDA_SDK_ROOT_DIR=${CUDA_PATH}/"
+    CMAKE_FLAGS+=" -DCUDA_TOOLKIT_INCLUDE=${CUDA_PATH}/include"
+    CMAKE_FLAGS+=" -DCUDA_TOOLKIT_ROOT_DIR=${CUDA_PATH}/"
+    CMAKE_FLAGS+=" -DCMAKE_CXX_FLAGS_RELEASE=-I/usr/include/nvidia/"
+    CMAKE_FLAGS+=" -DOPENMM_DIR=/anaconda/envs/_build"
+    export LD_LIBRARY_PATH=/anaconda/envs/_build/lib:$LD_LIBRARY_PATH
+    export LD_LIBRARY_PATH=$CUDA_PATH/lib64:$LD_LIBRARY_PATH
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+    CMAKE_FLAGS+=" -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++"
+    CMAKE_FLAGS+=" -DCMAKE_OSX_DEPLOYMENT_TARGET=10.9"
+    CMAKE_FLAGS+=" -DCUDA_SDK_ROOT_DIR=/Developer/NVIDIA/CUDA-7.5"
+    CMAKE_FLAGS+=" -DCUDA_TOOLKIT_ROOT_DIR=/Developer/NVIDIA/CUDA-7.5"
+    CMAKE_FLAGS+=" -DCMAKE_OSX_SYSROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.9.sdk"
+    CMAKE_FLAGS+=" -DOPENMM_DIR=/Users/travis/anaconda/envs/_build"
+    export LD_LIBRARY_PATH=/Users/travis/anaconda/envs/_build/lib:$LD_LIBRARY_PATH
+fi
+
+mkdir build
+cd build
+
+cmake .. $CMAKE_FLAGS
+make -j$CPU_COUNT all
+make -j$CPU_COUNT install PythonInstall

--- a/openmm-example-plugin/meta.yaml
+++ b/openmm-example-plugin/meta.yaml
@@ -1,0 +1,34 @@
+package:
+  name: openmm-example-plugin
+  version: "0.0.1"
+
+
+source:
+  git_url: https://github.com/peastman/openmmexampleplugin.git
+  git_rev: f1e12743d7c5403bb6d7ad8da69af6a2f27e1b26
+
+build:
+  skip:
+    - [win]
+    
+requirements:
+  build:
+    - openmm
+    - cmake
+    - python
+    - swig ==3.0.7
+
+  run:
+    - python
+    - openmm
+
+test:
+  requires:
+    - python
+    - openmm
+  imports:
+    - exampleplugin
+
+about:
+  home: https://github.com/peastman/openmmexampleplugin
+  summary: An example plugin for openmm


### PR DESCRIPTION
This adds the example plugin. 

While this doesn't add any useful end-functionality, I think it could be helpful to catch any changes that break plugins.

There is no windows build, as I'm unsure how to set that up correctly.