### PR TITLE
added funcsigs package with patch to circumvent ordereddict dependency

### DIFF
--- a/funcsigs/bld.bat
+++ b/funcsigs/bld.bat
@@ -1,0 +1,2 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1

--- a/funcsigs/build.sh
+++ b/funcsigs/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+$PYTHON setup.py install

--- a/funcsigs/meta.yaml
+++ b/funcsigs/meta.yaml
@@ -1,0 +1,38 @@
+package:
+  name: funcsigs
+  version: "1.0.0"
+
+source:
+  fn: funcsigs-1.0.0.tar.gz
+  url: https://pypi.python.org/packages/source/f/funcsigs/funcsigs-1.0.0.tar.gz
+  md5: 669d0f34e94cb36a3948e8f592bc6f25
+  patches:
+    - ordereddict.patch
+
+build:
+  noarch_python: True
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  number: 1
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - ordereddict # [py26]
+
+  run:
+    - python
+    - ordereddict # [py26]
+
+test:
+  # Python imports
+  imports:
+    - funcsigs
+
+about:
+  home: http://funcsigs.readthedocs.org
+  license: Apache Software License
+  summary: 'Python function signatures from PEP362 for Python 2.6, 2.7 and 3.2+'
+

--- a/funcsigs/ordereddict.patch
+++ b/funcsigs/ordereddict.patch
@@ -1,0 +1,29 @@
+diff --git a/setup.py b/setup.py
+index 6a08f29..35e49be 100644
+--- setup.py
++++ setup.py
+@@ -1,4 +1,5 @@
+ #!/usr/bin/env python
++from __future__ import print_function
+ from setuptools import setup
+ import re
+ import sys
+@@ -15,7 +16,7 @@ def load_version(filename='funcsigs/version.py'):
+         return version
+ 
+ 
+-setup(
++metadata=dict(
+     name="funcsigs",
+     version=load_version(),
+     packages=['funcsigs'],
+@@ -47,3 +48,9 @@ setup(
+     tests_require = ['unittest2'],
+     test_suite = 'unittest2.collector',
+ )
++if sys.version_info.major == 2 and sys.version_info.minor > 6:
++   print("omiting ordereddict dep")
++   ind = metadata['install_requires'].index('ordereddict')
++   del metadata['install_requires'][ind]
++
++setup(**metadata)

--- a/funcsigs/ordereddict.patch
+++ b/funcsigs/ordereddict.patch
@@ -1,5 +1,5 @@
 diff --git a/setup.py b/setup.py
-index 6a08f29..35e49be 100644
+index 6a08f29..5502397 100644
 --- setup.py
 +++ setup.py
 @@ -1,4 +1,5 @@
@@ -17,12 +17,15 @@ index 6a08f29..35e49be 100644
      name="funcsigs",
      version=load_version(),
      packages=['funcsigs'],
-@@ -47,3 +48,9 @@ setup(
+@@ -47,3 +48,12 @@ setup(
      tests_require = ['unittest2'],
      test_suite = 'unittest2.collector',
  )
-+if sys.version_info.major == 2 and sys.version_info.minor > 6:
-+   print("omiting ordereddict dep")
++major = sys.version_info.major
++minor = sys.version_info.minor
++
++if (major == 2 and sys.version_info.minor > 6) or (major > 2):
++   print("omitting ordereddict dep")
 +   ind = metadata['install_requires'].index('ordereddict')
 +   del metadata['install_requires'][ind]
 +


### PR DESCRIPTION
Background for this the hassle with Python-2.7 and the funcsigs package on conda:main, which falsely depends on ordereddict (which is not needed for Python > 2.6).

This ugly bug silently brakes conda-build.

https://github.com/conda/conda-build/issues/879