### PR TITLE
Add numpy 1.11 support to conda-build-all defaults

### DIFF
--- a/conda-build-all
+++ b/conda-build-all
@@ -91,7 +91,7 @@ def main():
         '--numpy',
         help="Set the NumPy version used by conda build",
         metavar="NUMPY_VER",
-        default='19,110',
+        default='19,110,111',
     )
     p.add_argument(
         '-v', '--verbose',


### PR DESCRIPTION
`anaconda` has added numpy 1.11 support to many packages, so it's time we add support too.