### PR TITLE
Update the check-outdated script

### DIFF
--- a/devtools/check-outdated
+++ b/devtools/check-outdated
@@ -116,28 +116,12 @@ def get_version_and_release_date(requirement, version=None,
                    'failed'.format(requirement, version))
         return None, None
 
-    try:
-        if version:
-            release_date = response['releases'][version][0]['upload_time']
-        else:
-            version = response['info']['stable_version']
+    if not version:
+        version = response['info']['version']
 
-            if not version:
-                versions = {parse_version(v): v for v in response['releases'].keys() if not parse_version(v).is_prerelease}
-                if len(versions) == 0:
-                    return None, None
-
-                version = versions[max(versions.keys())]
-                release_date = response['releases'][str(version)][0]['upload_time']
-
-        return version, datetime.fromtimestamp(time.mktime(
-            time.strptime(release_date, '%Y-%m-%dT%H:%M:%S')
-        ))
-    except IndexError:
-        if verbose:
-            print ('{} ({}) didn\'t return a date property'.format(requirement,
-                                                                   version))
-        return None, None
+    release_date = response['releases'][version][0]['upload_time']
+    return version, datetime.fromtimestamp(time.mktime(
+        time.strptime(release_date, '%Y-%m-%dT%H:%M:%S')))
 
 
 def get_pypi_url(requirement, version=None, base_url='https://pypi.python.org/pypi'):

--- a/graphviz/meta.yaml
+++ b/graphviz/meta.yaml
@@ -14,7 +14,7 @@ build:
   binary_relocation: true
   skip:
     - [not unix]
-    - [p3yk]
+    - [py3k]
 
 requirements:
   build:


### PR DESCRIPTION
```
$ devtools/check-outdated
autograd-1.1.2 outdated. version 1.1.4 is on pypi
autoprotocol-3.1.0 outdated. version 3.5.1 is on pypi
cvxcanon-0.0.21 outdated. version 0.0.23.4 is on pypi
cvxpy-0.3.1 outdated. version 0.4.0 is on pypi
funcsigs-1.0.0 outdated. version 1.0.2 is on pypi
hmmlearn-0.1.1 outdated. version 0.2.0 is on pypi
keras-0.3.2 outdated. version 1.0.2 is on pypi
latexcodec-1.0.1 outdated. version 1.0.3 is on pypi
nose-timer-0.5.0 outdated. version 0.6.0 is on pypi
numdifftools-0.9.14 outdated. version 0.9.16 is on pypi
paramz-0.1.5 outdated. version 0.5.5 is on pypi
pybtex-0.18 outdated. version 0.20.1 is on pypi
python-coveralls-2.5.0 outdated. version 2.7.0 is on pypi
pytools-2014.3.5 outdated. version 2016.1 is on pypi
schema-0.3.1 outdated. version 0.5.0 is on pypi
scs-1.1.7 outdated. version 1.2.6 is on pypi
sphinxcontrib-bibtex-0.3.2 outdated. version 0.3.3 is on pypi
subprocess32-3.2.6 outdated. version 3.2.7 is on pypi
```