### PR TITLE
Specify default upload label

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -65,5 +65,5 @@ build: false
 
 test_script:
   - ps: if (($env:APPVEYOR_PULL_REQUEST_NUMBER -eq $null) -and ($env:APPVEYOR_REPO_BRANCH -eq "master")) { $env:UPLOAD = "--upload omnia" } else { $env:UPLOAD = " " }
-  - "%CMD_IN_ENV% python conda-build-all %UPLOAD% --check-against omnia omnia/label/pre omnia/label/rc --python %CONDA_PY% *"
+  - "%CMD_IN_ENV% python conda-build-all %UPLOAD% --python %CONDA_PY% *"
 

--- a/conda-build-all
+++ b/conda-build-all
@@ -15,6 +15,12 @@ from distutils.spawn import find_executable
 
 BINSTAR_TOKEN = os.environ.pop('BINSTAR_TOKEN', None)
 
+# these labels will be checked by default for existent packages.
+STANDARD_LABELS = ('main',
+                   'dev',
+                   'rc',
+                   )
+
 try:
     from conda.utils import memoized
     import conda_build.build as conda_build_build
@@ -36,8 +42,6 @@ must run in the root conda environment.
   $ conda install conda-build anaconda-client''', file=sys.stderr)
     exit(1)
 
-# from conda import config as conda_config
-# conda_config.subdir = 'win-64'
 
 def main():
     p = argparse.ArgumentParser(
@@ -53,7 +57,8 @@ def main():
     p.add_argument(
         '--check-against',
         nargs="+",
-        metavar='BINSTAR_USER'
+        metavar='ANACONDA_USER/label/$name',
+        default=['omnia/label/%s' % label for label in STANDARD_LABELS],
     )
     p.add_argument(
         '--dry-run',
@@ -236,10 +241,11 @@ def upload_to_binstar(m, python, numpy, username, max_retries=5,
     elif dev:
         assert force, "Dev packages require forced uploads."
         cmd.extend(['--label', 'dev'])
+    elif m.section('extras') and 'upload' in m.section('extras'):
+        label = m.section('extras')['upload']
+        cmd.extend(['--label', label])
     else:
-        # By default, packages go to the "rc" release candidate label
-        # Please test these binaries before switching them to the main label.
-        cmd.extend(['--label', 'rc'])
+        cmd.extend(['--label', 'main'])
 
     err = None
     for i in range(max_retries):

--- a/devtools/docker-build.sh
+++ b/devtools/docker-build.sh
@@ -12,12 +12,11 @@ bash Miniconda3-latest-Linux-x86_64.sh -b -p /anaconda
 PATH=/opt/rh/devtoolset-2/root/usr/bin:/opt/rh/autotools-latest/root/usr/bin:/anaconda/bin:$PATH
 conda config --add channels omnia
 conda install -yq conda-build jinja2 anaconda-client
-checkagainst='omnia omnia/label/pre omnia/label/rc'
 
 if [[ "${TRAVIS_PULL_REQUEST}" == "false" ]]; then
-    /io/conda-build-all $UPLOAD --check-against $checkagainst -- /io/* || true
+    /io/conda-build-all $UPLOAD -- /io/* || true
 else
-    /io/conda-build-all -v -v -v $UPLOAD --check-against $checkagainst -- /io/*
+    /io/conda-build-all -vvv $UPLOAD -- /io/*
 fi
 
 #mv /anaconda/conda-bld/linux-64/*tar.bz2 /io/ || true

--- a/devtools/osx-build.sh
+++ b/devtools/osx-build.sh
@@ -10,9 +10,8 @@ bash Miniconda3-latest-MacOSX-x86_64.sh -b -p $HOME/anaconda;
 export PATH=$HOME/anaconda/bin:$PATH;
 conda config --add channels omnia;
 conda install -yq conda-build jinja2 anaconda-client;
-checkagainst='omnia omnia/label/pre omnia/label/rc'
 
-if ! ./conda-build-all --dry-run --check-against $checkagainst -- openmm* ; then
+if ! ./conda-build-all --dry-run -- openmm* ; then
     # Install OpenMM dependencies that can't be installed through
     # conda package manager (doxygen + CUDA)
     brew install -y --quiet doxygen
@@ -32,7 +31,7 @@ sudo tlmgr install titlesec framed threeparttable wrapfig multirow collection-fo
 
 # Build packages
 if [[ "${TRAVIS_PULL_REQUEST}" == "false" ]]; then
-    ./conda-build-all $UPLOAD --check-against $checkagainst -- * || true;
+    ./conda-build-all $UPLOAD  -- * || true;
 else
-    ./conda-build-all -v -v -v $UPLOAD --check-against $checkagainst -- *;
+    ./conda-build-all -vvv $UPLOAD -- *;
 fi;

--- a/openmm/meta.yaml
+++ b/openmm/meta.yaml
@@ -12,6 +12,10 @@ build:
     # don't build on Appveyor (no OpenCL / CUDA)
     - [ {{ os.environ.get('APPVEYOR', 'False') == 'True' }} ]
 
+# by default upload binaries to 'rc' channel on anaconda.org
+extras:
+  upload: rc
+
 requirements:
   build:
     # on windows, need to install cmake manually


### PR DESCRIPTION
    [conda-build-all] by default upload package to main. Recipes can specify label
    
    A meta.yaml can specify the channel to upload to within the extras section:
    
    extras:
      upload: rc
    
    Then all builds of this package will be uploaded specified channel only.
    
    Three default channels are now defined:
    1. main
    2. dev (development builds)
    3. rc (release candidates)