### PR TITLE
[conda-build-all] pre-releases go to rc now.

### DIFF
--- a/conda-build-all
+++ b/conda-build-all
@@ -237,12 +237,12 @@ def upload_to_binstar(m, python, numpy, username, max_retries=5,
     if force:
         cmd.extend(['--force'])
     if not pre_black_listed(m) and is_prerelease(m):
-        cmd.extend(['--label', 'pre'])
+        cmd.extend(['--label', 'dev'])
     elif dev:
         assert force, "Dev packages require forced uploads."
         cmd.extend(['--label', 'dev'])
-    elif m.section('extras') and 'upload' in m.section('extras'):
-        label = m.section('extras')['upload']
+    elif m.get_section('extras') and 'upload' in m.get_section('extras'):
+        label = m.get_section('extras')['upload']
         cmd.extend(['--label', label])
     else:
         cmd.extend(['--label', 'main'])


### PR DESCRIPTION
see discussion in #488 

Since we only want to use main, dev, rc for now, automatically detected development versions (eg. alpha, beta, rc1 and so on) will be moved to the dev label. This used to be pre before. So we should locate and move files in "pre" and move them to dev in the next step.

@jchodera please review.