### PR TITLE
Release msmb_data v2.0

### DIFF
--- a/msmb_data/bld.bat
+++ b/msmb_data/bld.bat
@@ -1,8 +1,3 @@
-"%PYTHON%" setup.py install
+mkdir "%PREFIX%\share\"
+xcopy msmb_data "%PREFIX%\share\msmb_data" /e /i /y
 if errorlevel 1 exit 1
-
-:: Add more build steps here, if they are necessary.
-
-:: See
-:: http://docs.continuum.io/conda/build.html
-:: for a list of environment variables that are set during the build process.

--- a/msmb_data/build.sh
+++ b/msmb_data/build.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-
-$PYTHON setup.py install
+mkdir -p $PREFIX/share/
+cp -r msmb_data $PREFIX/share/msmb_data

--- a/msmb_data/meta.yaml
+++ b/msmb_data/meta.yaml
@@ -1,42 +1,17 @@
 package:
   name: msmb_data
-  version: "1.0.0"
+  version: "2.0.0"
 
 source:
   git_url: https://github.com/msmbuilder/msmb_data.git
-  git_tag: 043676571130dab6c3fcca60d49a8d5f4dc99c59
+  git_tag: v2.0
 
 extra:
   maintainers:
    - cxhernandez
-
-requirements:
-  build:
-    - python
-    - setuptools
-    - cython
-    - numpy
-
-  run:
-    - python
-    - six
-    - msmbuilder
-    - numpy
-    - scipy
-
-test:
-  requires:
-    - nose
-    - nose-timer
-    - msmbuilder
-    - mdtraj
-  imports:
-    - msmb_data
-  commands:
-    - nosetests msmb_data -v --with-timer
-
+   - mpharrigan
 
 about:
-  home: https://github.com/msmbuilder/msmbuilder
-  license: LGPLv2.1+
+  home: https://github.com/msmbuilder/msmb_data
+  license: CC-BY
   summary: 'Testing data for MSMBuilder'


### PR DESCRIPTION
This package puts a couple hundred MB of example molecular dynamics data into your python prefix's `share/msmb_data` directory. We provide an API to fetch this data in `msmbuilder`. Other packages can use this data by loading the files

```python
import sys
"{prefix}/share/msmb_data/{dataset}/...".format(prefix=sys.prefix, dataset='fs_peptide')
```