### PR TITLE
[packmol] 2016.06.09 

### DIFF
--- a/packmol/meta.yaml
+++ b/packmol/meta.yaml
@@ -1,13 +1,13 @@
 package:
   name: packmol
-  version: 1.0.0
+  version: 2016.06.09
 
 source:
   fn: packmol.tar.gz
   url: http://www.ime.unicamp.br/~martinez/packmol/packmol.tar.gz
 
 build:
-  number: 4
+  number: 1
 
 requirements:
   build:

--- a/packmol/meta.yaml
+++ b/packmol/meta.yaml
@@ -8,6 +8,8 @@ source:
 
 build:
   number: 1
+  skip:
+    - [win and py35] # no mingwpy support for py35 on win
 
 requirements:
   build:


### PR DESCRIPTION
[Packmol](http://www.ime.unicamp.br/~martinez/packmol/download.shtml) does not use a versioned release system, so the best thing to do here is to update the version number to be the latest update date of the source tarball (which was manually verified to be 2016.06.09).