### PR TITLE
added progress_reporter lib.

### DIFF
--- a/progress_reporter/bld.bat
+++ b/progress_reporter/bld.bat
@@ -1,0 +1,3 @@
+"%PYTHON%" setup.py install 
+if errorlevel 1 exit 1
+

--- a/progress_reporter/build.sh
+++ b/progress_reporter/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+$PYTHON setup.py install 
+

--- a/progress_reporter/meta.yaml
+++ b/progress_reporter/meta.yaml
@@ -1,0 +1,34 @@
+package:
+  name: progress_reporter
+  version: "1.0.1"
+
+source:
+  git_url: https://github.com/marscher/progress_reporter
+  git_rev: v1.0.1
+
+build:
+  noarch_python: True
+  number: 0
+
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  # Python imports
+  imports:
+    - progress_reporter
+    - progress_reporter.bar
+
+about:
+  home: https://github.com/marscher/progress_reporter
+  license: MIT License
+  summary: 'interface for progress reporting'
+
+extra:
+  maintainers: Martin Scherer


### PR DESCRIPTION
We use this in PyEMMA to unify the progress reportage no matter of the backend (Jupyter and console).

@jhprinz asked me to cut it out, so he can use it OPS too.
@stefdoerr you might be interested as well, since this version is now going to be maintained.