### PR TITLE
Update schema to 0.6.2, enable py3k builds

### DIFF
--- a/conda-build-all
+++ b/conda-build-all
@@ -27,8 +27,8 @@ try:
     import conda_build.build as conda_build_build
     import conda.api
     import conda_build.index as conda_build_index
-    from conda.config import hide_binstar_tokens
-    # from conda_build.config import config as conda_build_config
+    # from conda.config import hide_binstar_tokens
+    from conda_build.config import config as conda_build_config
     from conda.config import subdir as platform
     assert platform in ('osx-64', 'linux-32', 'linux-64', 'win-32', 'win-64')
     from conda_build.metadata import MetaData

--- a/conda-build-all
+++ b/conda-build-all
@@ -28,14 +28,17 @@ try:
     import conda.api
     import conda_build.index as conda_build_index
     from conda.config import hide_binstar_tokens
-    from conda_build.config import config as conda_build_config
+    # from conda_build.config import config as conda_build_config
     from conda.config import subdir as platform
     assert platform in ('osx-64', 'linux-32', 'linux-64', 'win-32', 'win-64')
     from conda_build.metadata import MetaData
     from conda_build.config import Config as CondaBuildConfig
     from conda.utils import url_path
     BUILD_DIRECTORY = CondaBuildConfig.short_build_prefix
-except ImportError:
+except ImportError as e:
+    print('ImportError encountered:')
+    print(str(e))
+    print('')
     print('''This script requires conda-build and anaconda-client and
 must run in the root conda environment.
 

--- a/schema/meta.yaml
+++ b/schema/meta.yaml
@@ -1,15 +1,11 @@
 package:
   name: schema
-  version: !!str 0.5.0
+  version: !!str 0.6.2
 
 source:
-  fn: schema-0.5.0.tar.gz
-  url: https://pypi.python.org/packages/4b/eb/fadd6bc4967fded31495ea70aebd3bdc90b83e3944d08bfd841039062f83/schema-0.5.0.tar.gz
-  md5: cee375ebfa54f1c4a218438b3b1c6803
-
-build:
-  skip:
-    - [py3k]
+  fn: schema-0.6.2.tar.gz
+  url: https://pypi.python.org/packages/9b/3c/5924163d693f156684e1502df0b408512e18c70d7fa80244496fafdb5988/schema-0.6.2.tar.gz
+  mdf: ac1b359c31e9b37fbe9333902f6bdf76
 
 requirements:
   build:

--- a/schema/meta.yaml
+++ b/schema/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: schema
-  version: !!str 0.6.2
+  version: 0.6.2
 
 source:
   fn: schema-0.6.2.tar.gz
   url: https://pypi.python.org/packages/9b/3c/5924163d693f156684e1502df0b408512e18c70d7fa80244496fafdb5988/schema-0.6.2.tar.gz
-  mdf: ac1b359c31e9b37fbe9333902f6bdf76
+  md5: ac1b359c31e9b37fbe9333902f6bdf76
 
 requirements:
   build:


### PR DESCRIPTION
In part for the python 3 pledge, and to enable apps which depend on this to make their own py3k builds.