### PR TITLE
Made version number string again in schema

### DIFF
--- a/schema/meta.yaml
+++ b/schema/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: schema
-  version: 0.6.2
+  version: "0.6.2"
 
 source:
   fn: schema-0.6.2.tar.gz


### PR DESCRIPTION
Fix leftover issues from #584.

@mpharrigan Patching this here should correctly replace the build on the omnia conda channel, yes?