### PR TITLE
[openmmtools] Build win py3.5 packages

### DIFF
--- a/openmmtools/meta.yaml
+++ b/openmmtools/meta.yaml
@@ -10,8 +10,6 @@ build:
   number: 1
   skip:
     - [win32 or (win and py2k)]
-    # TODO no openmm py35 win
-    - [win and py35]
 
 requirements:
   build:
@@ -36,12 +34,8 @@ requirements:
     - parmed
 
 test:
-  requires:
-    - nose
   imports:
     - openmmtools
-  #commands:
-  #  - nosetests openmmtools --with-doctest --verbosity=2 --nocapture
 
 about:
   home: https://github.com/choderalab/openmmtools


### PR DESCRIPTION
This restores the ability to build `win` packages of `openmmtools` for python 3.5, now that there are `openmm` packages available.