### PR TITLE
Switch to conda build 2.0.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ services:
 env:
   global:
     - CONDA_BUILD: "2.0.1"
-    secure: "GjbAskNQDToMpTQ87p2TcG+JPdr+TIyWxarkzwd/KCQLuJqTKVVinWtKZwB+uaEnz2mmnXT7jFgbUU2Vuq0Dv78SOgTnqeh+ObP60imN4z8TB88PAFihv7JDJ45Nfbe7viKrWLWDYRebkObbJduc7xms0YEb9vs4e1+knTojiEc="
+    - secure: "GjbAskNQDToMpTQ87p2TcG+JPdr+TIyWxarkzwd/KCQLuJqTKVVinWtKZwB+uaEnz2mmnXT7jFgbUU2Vuq0Dv78SOgTnqeh+ObP60imN4z8TB88PAFihv7JDJ45Nfbe7viKrWLWDYRebkObbJduc7xms0YEb9vs4e1+knTojiEc="
     # The Dockerfile that defines the image that for the build environment is
 # available in this repo at devtools/centos5-build-box/Dockerfile
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,8 @@ services:
 
 env:
   global:
-    secure: "GjbAskNQDToMpTQ87p2TcG+JPdr+TIyWxarkzwd/KCQLuJqTKVVinWtKZwB+uaEnz2mmnXT7jFgbUU2Vuq0Dv78SOgTnqeh+ObP60imN4z8TB88PAFihv7JDJ45Nfbe7viKrWLWDYRebkObbJduc7xms0YEb9vs4e1+knTojiEc="
     - CONDA_BUILD: "2.0.1"
-
+    secure: "GjbAskNQDToMpTQ87p2TcG+JPdr+TIyWxarkzwd/KCQLuJqTKVVinWtKZwB+uaEnz2mmnXT7jFgbUU2Vuq0Dv78SOgTnqeh+ObP60imN4z8TB88PAFihv7JDJ45Nfbe7viKrWLWDYRebkObbJduc7xms0YEb9vs4e1+knTojiEc="
     # The Dockerfile that defines the image that for the build environment is
 # available in this repo at devtools/centos5-build-box/Dockerfile
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ services:
 env:
   global:
     secure: "GjbAskNQDToMpTQ87p2TcG+JPdr+TIyWxarkzwd/KCQLuJqTKVVinWtKZwB+uaEnz2mmnXT7jFgbUU2Vuq0Dv78SOgTnqeh+ObP60imN4z8TB88PAFihv7JDJ45Nfbe7viKrWLWDYRebkObbJduc7xms0YEb9vs4e1+knTojiEc="
-
+    CONDA_BUILD: "2.0.1"
 # The Dockerfile that defines the image that for the build environment is
 # available in this repo at devtools/centos5-build-box/Dockerfile
 install:
@@ -29,7 +29,7 @@ script:
 
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
 
-        docker run -e UPLOAD -e BINSTAR_TOKEN -e TRAVIS_PULL_REQUEST
+        docker run -e UPLOAD -e BINSTAR_TOKEN -e TRAVIS_PULL_REQUEST -e CONDA_BUILD
             -t -i --rm -v `pwd`:/io jchodera/omnia-build-box:latest
             bash /io/devtools/docker-build.sh;
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,10 @@ services:
   - docker
 
 env:
+  CONDA_BUILD: "2.0.1"
   global:
     secure: "GjbAskNQDToMpTQ87p2TcG+JPdr+TIyWxarkzwd/KCQLuJqTKVVinWtKZwB+uaEnz2mmnXT7jFgbUU2Vuq0Dv78SOgTnqeh+ObP60imN4z8TB88PAFihv7JDJ45Nfbe7viKrWLWDYRebkObbJduc7xms0YEb9vs4e1+knTojiEc="
-    CONDA_BUILD: "2.0.1"
-# The Dockerfile that defines the image that for the build environment is
+    # The Dockerfile that defines the image that for the build environment is
 # available in this repo at devtools/centos5-build-box/Dockerfile
 install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,10 @@ services:
   - docker
 
 env:
-  CONDA_BUILD: "2.0.1"
   global:
     secure: "GjbAskNQDToMpTQ87p2TcG+JPdr+TIyWxarkzwd/KCQLuJqTKVVinWtKZwB+uaEnz2mmnXT7jFgbUU2Vuq0Dv78SOgTnqeh+ObP60imN4z8TB88PAFihv7JDJ45Nfbe7viKrWLWDYRebkObbJduc7xms0YEb9vs4e1+knTojiEc="
+    - CONDA_BUILD: "2.0.1"
+
     # The Dockerfile that defines the image that for the build environment is
 # available in this repo at devtools/centos5-build-box/Dockerfile
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,7 @@ environment:
     CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\devtools\\appveyor\\run_with_env.cmd"
     BINSTAR_TOKEN:
       secure: 8ZUGhuOs5ffofdj5EqrwBaN+k9da2CbYVuve7QFl5SYvI0DwcfCcLw23GbkYKXoK
+    CONDA_BUILD: "2.0.1"
 
   matrix:
     - PYTHON: "C:\\Miniconda"
@@ -48,7 +49,7 @@ install:
   - conda config --add channels omnia
   - conda config --add channels salilab
   - conda update -yq --all
-  - conda install -yq conda-build=1.21.3 jinja2 anaconda-client
+  - conda install -yq conda-build="%CONDA_BUILD%" jinja2 anaconda-client
   - powershell .\\devtools\\appveyor\\missing-headers.ps1
   # conda-build for some inane reason, effectively puts C:\cygwin\bin at the
   # front of the PATH, ahead of everything else, regardless. See

--- a/conda-build-all
+++ b/conda-build-all
@@ -164,7 +164,7 @@ def sort_recipes(recipe_paths):
 
                 try:
                     m = MetaData(r)
-                except RuntimeError:
+                except (RuntimeError, IOError):
                     print('Failed to load %s' % r)
                     raise
                 metadatas.append(m)

--- a/conda-build-all
+++ b/conda-build-all
@@ -161,6 +161,7 @@ def sort_recipes(recipe_paths):
                 meta_yaml_filename = os.path.join(r, 'meta.yaml')
                 if not os.path.exists(meta_yaml_filename):
                     print("Skipping '%s' because no meta.yaml file found..." % r)
+                    continue
 
                 try:
                     m = MetaData(r)

--- a/conda-build-all
+++ b/conda-build-all
@@ -27,14 +27,15 @@ try:
     import conda_build.build as conda_build_build
     import conda.api
     import conda_build.index as conda_build_index
-    # from conda.config import hide_binstar_tokens
-    from conda_build.config import config as conda_build_config
     from conda.config import subdir as platform
     assert platform in ('osx-64', 'linux-32', 'linux-64', 'win-32', 'win-64')
     from conda_build.metadata import MetaData
-    from conda_build.config import Config as CondaBuildConfig
+    from conda_build.config import Config as _CondaBuildConfig
+    # default config instance
+    CondaBuildConfig = _CondaBuildConfig()
+    conda_build_config = CondaBuildConfig
     from conda.utils import url_path
-    BUILD_DIRECTORY = CondaBuildConfig.short_build_prefix
+    BUILD_DIRECTORY = CondaBuildConfig.build_prefix
 except ImportError as e:
     print('ImportError encountered:')
     print(str(e))
@@ -212,18 +213,19 @@ def conda_build_cmd():
 
 
 def get_bldpkg_path(m, python, numpy):
-    # globals used by conda-build to communicate python/numpy
-    # setting :(
-    conda_build_config.CONDA_PY = int(python.replace('.', ''))
-    conda_build_config.CONDA_NPY = int(numpy.replace('.', ''))
+    cfg = _CondaBuildConfig()
+    cfg.CONDA_PY = int(python.replace('.', ''))
+    cfg.CONDA_NPY = int(numpy.replace('.', ''))
+
+    m.config = cfg
     if m.info_index()['subdir'] == 'noarch':
-        conda_build_config.noarch = True
+        cfg.noarch = True
     else:
-        conda_build_config.noarch = False
+        cfg.noarch = False
     # need to re-parse jinja2 in light of changing config vars.
     # (esp. for skip() to work)
     m.parse_again()
-    return conda_build_build.bldpkg_path(m)
+    return conda_build_build.bldpkg_path(m, cfg)
 
 
 def list_package_contents(m, python, numpy):
@@ -300,7 +302,7 @@ def required_builds(metadatas, pythons, numpys, channel_urls, verbose,
                     force=False):
     if not os.path.isdir(conda_build_config.bldpkgs_dir):
         os.makedirs(conda_build_config.bldpkgs_dir)
-    conda_build_index.update_index(conda_build_config.bldpkgs_dir)
+    conda_build_index.update_index(conda_build_config.bldpkgs_dir, conda_build_config)
     index = conda.api.get_index(
         channel_urls=[url_path(conda_build_config.croot)] + list(channel_urls),
         prepend=False)

--- a/conda-build-all
+++ b/conda-build-all
@@ -31,10 +31,9 @@ try:
     assert platform in ('osx-64', 'linux-32', 'linux-64', 'win-32', 'win-64')
     from conda_build.metadata import MetaData
     from conda_build.config import Config as _CondaBuildConfig
+    from conda.utils import url_path
     # default config instance
     CondaBuildConfig = _CondaBuildConfig()
-    conda_build_config = CondaBuildConfig
-    from conda.utils import url_path
     BUILD_DIRECTORY = CondaBuildConfig.build_prefix
 except ImportError as e:
     print('ImportError encountered:')
@@ -300,11 +299,11 @@ class VersionIter(object):
 
 def required_builds(metadatas, pythons, numpys, channel_urls, verbose,
                     force=False):
-    if not os.path.isdir(conda_build_config.bldpkgs_dir):
-        os.makedirs(conda_build_config.bldpkgs_dir)
-    conda_build_index.update_index(conda_build_config.bldpkgs_dir, conda_build_config)
+    if not os.path.isdir(CondaBuildConfig.bldpkgs_dir):
+        os.makedirs(CondaBuildConfig.bldpkgs_dir)
+    conda_build_index.update_index(CondaBuildConfig.bldpkgs_dir, CondaBuildConfig)
     index = conda.api.get_index(
-        channel_urls=[url_path(conda_build_config.croot)] + list(channel_urls),
+        channel_urls=[url_path(CondaBuildConfig.croot)] + list(channel_urls),
         prepend=False)
     index_by_pkgname = defaultdict(dict)
     for k, v in index.items():

--- a/devtools/docker-build.sh
+++ b/devtools/docker-build.sh
@@ -11,7 +11,7 @@ curl -s -O https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
 bash Miniconda3-latest-Linux-x86_64.sh -b -p /anaconda
 PATH=/opt/rh/devtoolset-2/root/usr/bin:/opt/rh/autotools-latest/root/usr/bin:/anaconda/bin:$PATH
 conda config --add channels omnia
-conda install -yq conda-build=1.21.3 jinja2 anaconda-client
+conda install -yq conda-build=$CONDA_BUILD jinja2 anaconda-client
 
 if [[ "${TRAVIS_PULL_REQUEST}" == "false" ]]; then
     /io/conda-build-all $UPLOAD -- /io/* || true

--- a/devtools/osx-build.sh
+++ b/devtools/osx-build.sh
@@ -9,7 +9,7 @@ curl -s -O https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.s
 bash Miniconda3-latest-MacOSX-x86_64.sh -b -p $HOME/anaconda;
 export PATH=$HOME/anaconda/bin:$PATH;
 conda config --add channels omnia;
-conda install -yq conda-build=1.21.3 jinja2 anaconda-client;
+conda install -yq conda-build=$CONDA_BUILD jinja2 anaconda-client;
 
 if ! ./conda-build-all --dry-run -- openmm* ; then
     # Install OpenMM dependencies that can't be installed through


### PR DESCRIPTION
Changed conda-build-all to support conda-build 2.0 and pinned it in the scripts via the env variable "CONDA_BUILD", so we can easily change that.

Rationale: the new version supports to get version numbers dynamically and it provides lots of bug fixes. 

However we need to carefully test this. I ran several tests locally and it works so far. 

Should I also add a new dummy recipe in this PR (temporarily) to prove it does what it should?