### PR TITLE
Bump version on openbabel to 2.4.0

### DIFF
--- a/openbabel/meta.yaml
+++ b/openbabel/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: openbabel
-  version: "1!2.4.0"
+  version: "2.4.0"
 
 source:
   url: https://github.com/openbabel/openbabel/archive/openbabel-2-4-0.zip 

--- a/openbabel/meta.yaml
+++ b/openbabel/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: openbabel
-  version: 2015.09
+  version: "2.4.0"
 
 source:
   url: https://github.com/openbabel/openbabel/archive/openbabel-2-4-0.zip 

--- a/openbabel/meta.yaml
+++ b/openbabel/meta.yaml
@@ -3,8 +3,8 @@ package:
   version: 2015.09
 
 source:
-  url: https://github.com/openbabel/openbabel/archive/2d45874928002488b3e9f72b0d489c3062add716.zip
-  fn: 2d45874928002488b3e9f72b0d489c3062add716.zip
+  url: https://github.com/openbabel/openbabel/archive/openbabel-2-4-0.zip 
+  fn: openbabel-2-4-0.zip 
 
   patches:
     - include-dirs.patch

--- a/openbabel/meta.yaml
+++ b/openbabel/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: openbabel
-  version: "2.4.0"
+  version: "1!2.4.0"
 
 source:
   url: https://github.com/openbabel/openbabel/archive/openbabel-2-4-0.zip 


### PR DESCRIPTION
I'm hoping the build goes through without any issues. If it does, will remove [WIP] tag. If not, then might take some effort to figure out what need to be fixed in version upgrade.