### PR TITLE
Updating YANK to version 0.11.2

### DIFF
--- a/yank/meta.yaml
+++ b/yank/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: yank
-  version: "0.11.0"
+  version: "0.11.2"
 
 source:
     git_url: https://github.com/choderalab/yank.git
-    git_tag: "0.11.0"
+    git_tag: "0.11.2"
 
 build:
   number: 0

--- a/yank/meta.yaml
+++ b/yank/meta.yaml
@@ -1,14 +1,13 @@
 package:
   name: yank
-  version: 0.10.0
+  version: "0.11.0"
 
 source:
     git_url: https://github.com/choderalab/yank.git
-    git_tag: 0.10.0
+    git_tag: "0.11.0"
 
 build:
   number: 0
-  skip:
   skip:
     - [win]
 
@@ -29,7 +28,7 @@ requirements:
     - openmoltools
     - sphinxcontrib-bibtex
     - alchemy >=1.2.1
-    - schema >=0.5.0
+    - schema >=0.6.2
     #- gcc 4.8.2 # [linux]
     #- gcc 4.8.2 # [osx]
 
@@ -52,7 +51,7 @@ requirements:
     - clusterutils
     - sphinxcontrib-bibtex
     - alchemy >=1.2.1
-    - schema >=0.5.0
+    - schema >=0.6.2
     #- libgcc
 
 test:


### PR DESCRIPTION
Updates YANK to 0.11.0

- Version number is now a string
- Fixed Schema dependency