### PR TITLE
Specify old osx image (xcode6.1) to recover previous behavior

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ os:
 
 # This image will expire on 31 Oct 2016, at which point we need to change to xcode6.4
 # https://blog.travis-ci.com/2016-10-04-osx-73-default-image-live/
-osx_image: xcode6.1
+# Supported versions: https://docs.travis-ci.com/user/languages/objective-c/#Supported-Xcode-versions
+osx_image: beta-xcode6.1
 
 language: c
 sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ os:
   - linux
   - osx
 
+# This image will expire on 31 Oct 2016, at which point we need to change to xcode6.4
+# https://blog.travis-ci.com/2016-10-04-osx-73-default-image-live/
+osx_image: xcode6.1
+
 language: c
 sudo: required
 


### PR DESCRIPTION
Fixes https://github.com/omnia-md/conda-recipes/issues/605

Travis has [updated its `osx` image](https://blog.travis-ci.com/2016-10-04-osx-73-default-image-live/), causing issues with the `osx` builds. 

This PR restores the old `xcode6.1` image, but that image will expire 31 Oct 2016, at which point we will need to update to at least `xcode6.4`