### PR TITLE
[WIP] Testing for OpenMM 7.1 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
 # available in this repo at devtools/centos5-build-box/Dockerfile
 install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-      docker pull jchodera/omnia-build-box;
+      docker pull jchodera/omnia-build-box:cuda80-amd30;
     fi
 
 script:
@@ -35,7 +35,7 @@ script:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
 
         docker run -e UPLOAD -e BINSTAR_TOKEN -e TRAVIS_PULL_REQUEST -e CONDA_BUILD
-            -t -i --rm -v `pwd`:/io jchodera/omnia-build-box:latest
+            -t -i --rm -v `pwd`:/io jchodera/omnia-build-box:cuda80-amd30
             bash /io/devtools/docker-build.sh;
 
     elif [[ "$TRAVIS_OS_NAME" == "osx" ]]; then

--- a/devtools/osx-build.sh
+++ b/devtools/osx-build.sh
@@ -15,8 +15,8 @@ if ! ./conda-build-all --dry-run -- openmm* ; then
     # Install OpenMM dependencies that can't be installed through
     # conda package manager (doxygen + CUDA)
     brew install -y --quiet doxygen
-    curl -O -s http://developer.download.nvidia.com/compute/cuda/7.5/Prod/network_installers/mac/x86_64/cuda_mac_installer_tk.tar.gz
-    curl -O -s http://developer.download.nvidia.com/compute/cuda/7.5/Prod/network_installers/mac/x86_64/cuda_mac_installer_drv.tar.gz
+    curl -O -s http://developer.download.nvidia.com/compute/cuda/8.0/Prod/network_installers/mac/x86_64/cuda_mac_installer_tk.tar.gz
+    curl -O -s http://developer.download.nvidia.com/compute/cuda/8.0/Prod/network_installers/mac/x86_64/cuda_mac_installer_drv.tar.gz
     sudo tar -zxf cuda_mac_installer_tk.tar.gz -C /;
     sudo tar -zxf cuda_mac_installer_drv.tar.gz -C /;
     rm -f cuda_mac_installer_tk.tar.gz cuda_mac_installer_drv.tar.gz

--- a/openmm/meta.yaml
+++ b/openmm/meta.yaml
@@ -4,12 +4,12 @@ package:
 
 source:
   git_url: https://github.com/pandegroup/openmm.git
-  git_rev: 65be515
+  git_rev: 064a781
 
 build:
   number: 0
   skip: True # [win]
-  
+
 # by default upload binaries to 'rc' channel on anaconda.org
 extra:
   upload: rc

--- a/openmm/meta.yaml
+++ b/openmm/meta.yaml
@@ -1,15 +1,15 @@
 package:
   name: openmm
-  version: 7.0.1
+  version: 7.1.0
 
 source:
   git_url: https://github.com/pandegroup/openmm.git
-  git_rev: 5e86c4f
+  git_rev: 65be515
 
 build:
   number: 0
   skip: True # [win]
-
+  
 # by default upload binaries to 'rc' channel on anaconda.org
 extra:
   upload: rc
@@ -23,8 +23,8 @@ requirements:
     # Pin fftw3f to 3.3.3 to work around OSX py34 issues
     - fftw3f ==3.3.3 [not win]
     - fftw3f ==3.3.4 [win]
-    # swig is pinned to use omnia swig 3.0.7
-    - swig ==3.0.7
+    # swig is pinned to use omnia swig 3.0.8
+    - swig ==3.0.8
     # on osx, need to install doxygen manually
     - doxygen   [not osx]
     # for building docs

--- a/openmm/meta.yaml
+++ b/openmm/meta.yaml
@@ -7,7 +7,7 @@ source:
   git_rev: 064a781
 
 build:
-  number: 0
+  number: 1 # needed to override 'dev' build
   skip: True # [win]
 
 # by default upload binaries to 'rc' channel on anaconda.org

--- a/swig/meta.yaml
+++ b/swig/meta.yaml
@@ -1,14 +1,14 @@
 package:
   name: swig
-  version: 3.0.7
+  version: 3.0.8
 
 source:
-  fn: swigwin-3.0.7.zip                                                     [win]
-  url: http://prdownloads.sourceforge.net/swig/swigwin-3.0.7.zip            [win]
-  sha256: 11423c4a37209ea501d04d2bf7f71c275cf418b93a28cf062c87b3c1fdfbe286  [win]
-  fn: swig-3.0.7.tar.gz                                                 [not win]
-  md5: 7fff46c84b8c630ede5b0f0827e3d90a                                 [not win]
-  url: http://prdownloads.sourceforge.net/swig/swig-3.0.7.tar.gz        [not win]
+  fn: swigwin-3.0.8.zip                                                     [win]
+  url: http://prdownloads.sourceforge.net/swig/swigwin-3.0.8.zip            [win]
+  sha256: e5fe65ae9b145ea3c00172abdb527f2d3458e8cc928e25db984b2da1b00a2a04  [win]
+  fn: swig-3.0.8.tar.gz                                                 [not win]
+  md5: c96a1d5ecb13d38604d7e92148c73c97                                 [not win]
+  url: http://prdownloads.sourceforge.net/swig/swig-3.0.8.tar.gz        [not win]
 
 build:
   detect_binary_files_with_prefix: True


### PR DESCRIPTION
This is the first stage of testing an OpenMM 7.1 build.

We're currently still using the Linux CUDA 7.5 docker image, but this will be upgraded soon.
