### PR TITLE
Critical fix for the  MD5 issue for ambermini

### DIFF
--- a/ambermini/meta.yaml
+++ b/ambermini/meta.yaml
@@ -5,10 +5,9 @@ package:
 source:
   fn: 16.16.0.zip
   url: https://github.com/choderalab/ambermini/archive/16.16.0.zip
-  md5: 2969b5b042a0ebd83ead860a9a8c4d2e
 
 build:
-  number: 5
+  number: 6
   skip: True [win]
 
 requirements:


### PR DESCRIPTION
The MD5 hash on the github release tarbal keeps changing, this is causing all builds of ambermini to fail. This removes the MD5 check and updates build number to hopefully get the omnia channel to update is release