### PR TITLE
[mdtraj] Add mdtraj 1.8.0 recipe temporarily until build system migrated to CentOS 6

### DIFF
--- a/mdtraj/1208-find-zlib.patch
+++ b/mdtraj/1208-find-zlib.patch
@@ -1,0 +1,30 @@
+From 4ccffb790d4adfbd8c119855b083f1301a5264b9 Mon Sep 17 00:00:00 2001
+From: Matthew Harrigan <harrigan@stanford.edu>
+Date: Wed, 9 Nov 2016 17:00:19 -0800
+Subject: [PATCH] Install path for zlib on linux (too)
+
+---
+ setup.py | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/setup.py b/setup.py
+index e3ac9e6..02be8a9 100644
+--- a/setup.py
++++ b/setup.py
+@@ -119,10 +119,14 @@ def format_extensions():
+     if sys.platform == 'win32':
+         # Conda puts the zlib headers in ./Library/... on windows
+         # If you're not using conda, good luck!
+-        # (on linux, zlib is a dependency of python and its headers/libraries
+-        #  go in the normal ./include ./lib directories)
+         zlib_include_dirs += ["{}/Library/include".format(sys.prefix)]
+         zlib_library_dirs += ["{}/Library/lib".format(sys.prefix)]
++    else:
++        # On linux (and mac(?)) these paths should work for a standard
++        # install of python+zlib or a conda install of python+zlib
++        zlib_include_dirs += ["{}/include".format(sys.prefix)]
++        zlib_library_dirs += ["{}/lib".format(sys.prefix)]
++
+     tng = Extension('mdtraj.formats.tng',
+                     sources=glob('mdtraj/formats/tng/src/compression/*.c') +
+                                 ['mdtraj/formats/tng/src/lib/tng_io.c',

--- a/mdtraj/bld.bat
+++ b/mdtraj/bld.bat
@@ -1,0 +1,2 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1

--- a/mdtraj/build.sh
+++ b/mdtraj/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+pip install .

--- a/mdtraj/meta.yaml
+++ b/mdtraj/meta.yaml
@@ -1,0 +1,44 @@
+package:
+  name: mdtraj
+  version: "1.8.0"
+
+source:
+  fn: mdtraj-1.8.0.tar.gz
+  url: https://pypi.python.org/packages/cd/9f/027fa58d4e93dd3d700e22d5766961c970f6882c2bffd33daef55219d078/mdtraj-1.8.0.tar.gz#md5=b350f3ce5deba70d824e9420ae53b00a
+  md5: b350f3ce5deba70d824e9420ae53b00a
+
+build:
+  number: 1
+  entry_points:
+    - mdconvert = mdtraj.scripts.mdconvert:entry_point
+    - mdinspect = mdtraj.scripts.mdinspect:entry_point
+  patches:
+    # Necessary for building 1.8.0, should be fixed by next version
+    - 1208-find-zlib.patch
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - cython
+    - numpy x.x
+    - zlib 1.2.*
+
+  run:
+    - python
+    - setuptools
+    - numpy x.x
+    - scipy
+    - pandas
+    - pytables
+    
+test:
+  imports:
+    - mdtraj
+  commands:
+    - mdconvert -h
+
+about:
+  home: http://mdtraj.org/
+  license: GNU Lesser General Public License v2 or later (LGPLv2+)
+  summary: A modern, open library for the analysis of molecular dynamics trajectories


### PR DESCRIPTION
cc: #662 #634 #645 

For now, we need certain packages to still be built by the omnia build system until we migrate the build system to CentOS 6 for conda-forge compatibility.