### PR TITLE
Don't pin conda-build to 2.0.1 due to API incompatibilities with 'conda'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ services:
 
 env:
   global:
-    - CONDA_BUILD: "2.0.1"
     - CUDA_VERSION: "8.0"
     - CUDA_SHORT_VERSION: "80"
   secure:
@@ -37,7 +36,7 @@ script:
 
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
 
-        docker run -e UPLOAD -e BINSTAR_TOKEN -e TRAVIS_PULL_REQUEST -e CONDA_BUILD
+        docker run -e UPLOAD -e BINSTAR_TOKEN -e TRAVIS_PULL_REQUEST
             -t -i --rm -v `pwd`:/io jchodera/omnia-build-box:cuda${CUDA_SHORT_VERSION}-amd30-clang38
             bash /io/devtools/docker-build.sh;
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,6 @@ environment:
     PYTHONUNBUFFERED: 1
     BINSTAR_TOKEN:
       secure: gseoZQcKcNhwmxUa8QCSfqPrMda9GMur/K24BZlp+I7BasK4igU2vg40+r7QyolZuLHWazznNQPIYk/Gf5dMgX4ZxRuuhV03dj9qZHttLyhyDQ6sIMvoW0GQ9QXwVAbzt6zRnfGK+aeTc2ZDYC2PlQ9+NxBaZj4nnMotj6iYygtB9s54hQNqHt5trMJrpe1SIZWeY5p4KFY6HohiSFohtPDugKeMPzn1EkAGQfsvpD8=
-    CONDA_BUILD: "2.0.1"
 
   matrix:
     - PYTHON: "C:\\Miniconda"
@@ -50,7 +49,7 @@ install:
   - conda config --add channels omnia
   - conda config --add channels salilab
   - conda update -yq --all
-  - conda install -yq conda-build="%CONDA_BUILD%" jinja2 anaconda-client
+  - conda install -yq conda-build jinja2 anaconda-client
   - powershell .\\devtools\\appveyor\\missing-headers.ps1
   # conda-build for some inane reason, effectively puts C:\cygwin\bin at the
   # front of the PATH, ahead of everything else, regardless. See

--- a/conda-build-all
+++ b/conda-build-all
@@ -25,7 +25,7 @@ STANDARD_LABELS = ('main',
 
 try:
     from conda.utils import memoized
-    import conda_build.build as conda_build_build
+    from conda_build.api import get_output_file_path
     import conda.api
     import conda_build.index as conda_build_index
     from conda.config import subdir as platform
@@ -226,8 +226,7 @@ def get_bldpkg_path(m, python, numpy):
     # need to re-parse jinja2 in light of changing config vars.
     # (esp. for skip() to work)
     m.parse_again()
-    return conda_build_build.bldpkg_path(m, cfg)
-
+    return get_output_file_path(m, cfg)
 
 def list_package_contents(m, python, numpy):
     filename = get_bldpkg_path(m, python, numpy)

--- a/conda-build-all
+++ b/conda-build-all
@@ -225,7 +225,7 @@ def get_bldpkg_path(m, python, numpy):
         cfg.noarch = False
     # need to re-parse jinja2 in light of changing config vars.
     # (esp. for skip() to work)
-    m.parse_again()
+    m.parse_again()    
     return get_output_file_path(m, cfg)
 
 def list_package_contents(m, python, numpy):

--- a/conda-build-all
+++ b/conda-build-all
@@ -225,7 +225,7 @@ def get_bldpkg_path(m, python, numpy):
         cfg.noarch = False
     # need to re-parse jinja2 in light of changing config vars.
     # (esp. for skip() to work)
-    m.parse_again()    
+    m.parse_again()
     return get_output_file_path(m, cfg)
 
 def list_package_contents(m, python, numpy):
@@ -310,7 +310,8 @@ def required_builds(metadatas, pythons, numpys, channel_urls, verbose,
         prepend=False)
     index_by_pkgname = defaultdict(dict)
     for k, v in index.items():
-        channel, pkgname = k.split('::')
+        channel = k.channel
+        pkgname = k.to_filename()
         index_by_pkgname[pkgname][channel] = v
 
     for m in metadatas:

--- a/devtools/docker-build.sh
+++ b/devtools/docker-build.sh
@@ -14,7 +14,7 @@ conda config --add channels omnia
 conda install -yq conda-build jinja2 anaconda-client
 
 if [[ "${TRAVIS_PULL_REQUEST}" == "false" ]]; then
-    /io/conda-build-all $UPLOAD -- /io/* || true
+    /io/conda-build-all -vvv $UPLOAD -- /io/* || true
 else
     /io/conda-build-all -vvv $UPLOAD -- /io/*
 fi

--- a/devtools/docker-build.sh
+++ b/devtools/docker-build.sh
@@ -11,7 +11,7 @@ curl -s -O https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
 bash Miniconda3-latest-Linux-x86_64.sh -b -p /anaconda
 PATH=/opt/rh/devtoolset-2/root/usr/bin:/anaconda/bin:$PATH
 conda config --add channels omnia
-conda install -yq conda-build=$CONDA_BUILD jinja2 anaconda-client
+conda install -yq conda-build jinja2 anaconda-client
 
 if [[ "${TRAVIS_PULL_REQUEST}" == "false" ]]; then
     /io/conda-build-all $UPLOAD -- /io/* || true

--- a/devtools/osx-build.sh
+++ b/devtools/osx-build.sh
@@ -11,7 +11,7 @@ curl -s -O https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.s
 bash Miniconda3-latest-MacOSX-x86_64.sh -b -p $HOME/anaconda;
 export PATH=$HOME/anaconda/bin:$PATH;
 conda config --add channels omnia;
-conda install -yq conda-build=$CONDA_BUILD jinja2 anaconda-client;
+conda install -yq conda-build jinja2 anaconda-client;
 
 if ! ./conda-build-all --dry-run -- openmm* ; then
     # Install OpenMM dependencies that can't be installed through

--- a/devtools/osx-build.sh
+++ b/devtools/osx-build.sh
@@ -11,9 +11,12 @@ curl -s -O https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.s
 bash Miniconda3-latest-MacOSX-x86_64.sh -b -p $HOME/anaconda;
 export PATH=$HOME/anaconda/bin:$PATH;
 conda config --add channels omnia;
+conda config --show;
 conda install -yq conda-build jinja2 anaconda-client;
 
-if ! ./conda-build-all --dry-run -- openmm* ; then
+#export INSTALL_CUDA=`./conda-build-all --dry-run -- openmm`
+export INSTALL_OPENMM_PREREQUISITES=true
+if [ "$INSTALL_OPENMM_PREREQUISITES" = true ] ; then
     # Install OpenMM dependencies that can't be installed through
     # conda package manager (doxygen + CUDA)
     brew install -y --quiet doxygen
@@ -22,13 +25,13 @@ if ! ./conda-build-all --dry-run -- openmm* ; then
     sudo tar -zxf cuda_mac_installer_tk.tar.gz -C /;
     sudo tar -zxf cuda_mac_installer_drv.tar.gz -C /;
     rm -f cuda_mac_installer_tk.tar.gz cuda_mac_installer_drv.tar.gz
-fi;
 
-# Install latex.
-brew cask install -y basictex
-export PATH="/usr/texbin:${PATH}:/usr/bin"
-sudo tlmgr update --self
-sudo tlmgr install titlesec framed threeparttable wrapfig multirow collection-fontsrecommended hyphenat xstring
+    # Install latex.
+    brew cask install -y basictex
+    export PATH="/usr/texbin:${PATH}:/usr/bin"
+    sudo tlmgr update --self
+    sudo tlmgr install titlesec framed threeparttable wrapfig multirow collection-fontsrecommended hyphenat xstring
+fi;
 
 # Build packages
 if [[ "${TRAVIS_PULL_REQUEST}" == "false" ]]; then

--- a/devtools/osx-build.sh
+++ b/devtools/osx-build.sh
@@ -30,7 +30,8 @@ if [ "$INSTALL_OPENMM_PREREQUISITES" = true ] ; then
     brew cask install -y basictex
     export PATH="/usr/texbin:${PATH}:/usr/bin"
     sudo tlmgr update --self
-    sudo tlmgr install titlesec framed threeparttable wrapfig multirow collection-fontsrecommended hyphenat xstring
+    sleep 5
+    sudo tlmgr --persistent-downloads install titlesec framed threeparttable wrapfig multirow collection-fontsrecommended hyphenat xstring
 fi;
 
 # Build packages


### PR DESCRIPTION
Supercedes #670 by updating `linux`, `osx`, and `win` builds (though there are likely other problems with the appveyor build).