### PR TITLE
Unpin meld's swig version to unbreak from conda update

### DIFF
--- a/meld-plugin/meta.yaml
+++ b/meld-plugin/meta.yaml
@@ -15,7 +15,7 @@ requirements:
     - openmm-dev
     - cmake
     - python
-    - swig ==3.0.7
+    - swig
     - eigen3
 
   run:


### PR DESCRIPTION
Partially addresses #675

Still need to find a proactive way to catch these