### PR TITLE
Rebuild packages from conda-build break

### DIFF
--- a/deepchem/meta.yaml
+++ b/deepchem/meta.yaml
@@ -7,7 +7,7 @@ source:
     git_tag: 0.0.4
 
 build:
-  number: 0
+  number: 1
   skip: True  # [osx or win or py3k]
 
 

--- a/deepchem/meta.yaml
+++ b/deepchem/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: "0.0.4"
 
 source:
-    git_url: https://github.com/pandegroup/deepchem/
+    git_url: https://github.com/pandegroup/deepchem.git
     git_tag: 0.0.4
 
 build:

--- a/openbabel/meta.yaml
+++ b/openbabel/meta.yaml
@@ -12,7 +12,7 @@ source:
     - fix_data_path.diff
 
 build:
-  number: 1
+  number: 2
   detect_binary_files_with_prefix: true
   skip: True  # [win]
 


### PR DESCRIPTION
The following package was still broken from the conda-build kerfluffle. 
* deepchem

The following package could not build due to other `conda` related problems:
* parmed 
    * MD5 Mismatch, the tarball on GitHub changed its MD5 signature. 
    * If a new version is cut, the MD5 will be updated and wont be an issue. 
    * If we have to _rebuild_ the current version this will be a problem.
    * cc @swail package maintainer in case this is important. 

All other packages were able to `conda build` without the placeholder length error. There were a few that could not build due to various other errors that seem to be program specific, and not related to the `conda` problems.

Its worth noting that the `nightli.es` would never have caught this since it does not actually try rebuilding packages unless the version or build number is incremented.
