### PR TITLE
Don't add conda build dir as channel

### DIFF
--- a/conda-build-all
+++ b/conda-build-all
@@ -302,11 +302,8 @@ class VersionIter(object):
 
 def required_builds(metadatas, pythons, numpys, channel_urls, verbose,
                     force=False):
-    if not os.path.isdir(CondaBuildConfig.bldpkgs_dir):
-        os.makedirs(CondaBuildConfig.bldpkgs_dir)
-    conda_build_index.update_index(CondaBuildConfig.bldpkgs_dir, CondaBuildConfig)
     index = conda.api.get_index(
-        channel_urls=[url_path(CondaBuildConfig.croot)] + list(channel_urls),
+        channel_urls=list(channel_urls),
         prepend=False)
     index_by_pkgname = defaultdict(dict)
     for k, v in index.items():


### PR DESCRIPTION
This might address #690.

I am not sure if this is a valid thing to change, as I don't quite understand the rationale for adding the build dir as a channel in the first place.

We either need to:
1. not add the build dir (as in this PR), or
2. make sure that the build dir has the right structure, to avoid warnings about the lack of a noarch directory and crashes with the latest version of conda.