### PR TITLE
Revert previous changes; add and index noarch

### DIFF
--- a/conda-build-all
+++ b/conda-build-all
@@ -308,7 +308,7 @@ def required_builds(metadatas, pythons, numpys, channel_urls, verbose,
     noarch_path = os.path.join(CondaBuildConfig.croot, 'noarch')
     if not os.path.isdir(noarch_path):
         os.makedirs(noarch_path)
-    conda_build_index.update_index(noarch_path, conda_build_index, force=True)
+    conda_build_index.update_index(noarch_path, CondaBuildConfig, force=True)
     index = conda.api.get_index(
         channel_urls=[url_path(CondaBuildConfig.croot)] + list(channel_urls),
         prepend=False)

--- a/conda-build-all
+++ b/conda-build-all
@@ -302,8 +302,15 @@ class VersionIter(object):
 
 def required_builds(metadatas, pythons, numpys, channel_urls, verbose,
                     force=False):
+    if not os.path.isdir(CondaBuildConfig.bldpkgs_dir):
+        os.makedirs(CondaBuildConfig.bldpkgs_dir)
+    conda_build_index.update_index(CondaBuildConfig.bldpkgs_dir, CondaBuildConfig)
+    noarch_path = os.path.join(CondaBuildConfig.croot, 'noarch')
+    if not os.path.isdir(noarch_path):
+        os.makedirs(noarch_path)
+    conda_build_index.update_index(noarch_path, conda_build_index, force=True)
     index = conda.api.get_index(
-        channel_urls=list(channel_urls),
+        channel_urls=[url_path(CondaBuildConfig.croot)] + list(channel_urls),
         prepend=False)
     index_by_pkgname = defaultdict(dict)
     for k, v in index.items():


### PR DESCRIPTION
This reverts commit f4808280225dd011f137fd86d0c662519f919a63.

Attempts to add a noarch directory that conda expects and creates an index file for it.