### PR TITLE
[conda-build-all] ignore combination py36 and np110

### DIFF
--- a/conda-build-all
+++ b/conda-build-all
@@ -316,6 +316,11 @@ def required_builds(metadatas, pythons, numpys, channel_urls, verbose,
         last_base_bldpkg_path = None
         for python in VersionIter('python', m, pythons):
             for numpy in VersionIter('numpy', m, numpys):
+                if python == "3.6" and numpy == "110":
+                    if verbose > 1:
+                        print("skipping python 3.6 and numpy 1.10")
+                    continue
+
                 bldpkg_path = get_bldpkg_path(m, python, numpy)
                 base_bldpkg_path = os.path.basename(bldpkg_path)
 


### PR DESCRIPTION
Numpy 1.10 is not available (at the moment?) in default channel, so we skip this combination for now. See #702 