### PR TITLE
Don't build sphinxcontrib-* as noarch

### DIFF
--- a/sphinxcontrib-autodoc_doxygen/meta.yaml
+++ b/sphinxcontrib-autodoc_doxygen/meta.yaml
@@ -8,8 +8,8 @@ source:
   md5: fcfbc77a810900865b143b7aa9409e2f
 
 build:
-  noarch_python: True
-  number: 0
+  #noarch_python: True # this causes problems
+  number: 1
   skip: True  # [win]
 
 requirements:

--- a/sphinxcontrib-lunrsearch/meta.yaml
+++ b/sphinxcontrib-lunrsearch/meta.yaml
@@ -7,8 +7,8 @@ source:
   url: https://pypi.python.org/packages/source/s/sphinxcontrib-lunrsearch/sphinxcontrib-lunrsearch-0.2.tar.gz
 
 build:
-  noarch_python: True
-  number: 0
+  #noarch_python: True # this causes problems
+  number: 1
   skip: True  # [win]
 
 requirements:


### PR DESCRIPTION
The `noarch` packages `sphinxcontrib-*` were causing problems with Python 3.6 builds because, even though they were `noarch`, anaconda foolishly cannot identify them as being available when Python 3.6 is in use. Removing `noarch` for now.