### PR TITLE
Disable RDKit on OSX

### DIFF
--- a/rdkit/meta.yaml
+++ b/rdkit/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   number: 3
-  skip: True  # [win]
+  skip: True  # [win or osx]
 
 requirements:
   build:


### PR DESCRIPTION
Its too slow to build before Travis times out preventing other packages from building.