### PR TITLE
Fix cvxpy sloppy build reqs

### DIFF
--- a/cvxpy/meta.yaml
+++ b/cvxpy/meta.yaml
@@ -21,6 +21,7 @@ requirements:
     - setuptools
     - cvxcanon >=0.0.22
     - six
+    - fastcache
 
   run:
     - python
@@ -33,6 +34,7 @@ requirements:
     - cvxopt
     - cvxcanon >=0.0.22
     - six
+    - fastcache
 
 test:
   requires:


### PR DESCRIPTION
CvxPy has some odd requirements that don't provide an unbroken chain of dependencies. this causes `setuptools` to try and fetch the dependencies instead of `conda-build` which causes the errors this fixes.