### PR TITLE
Adding coverage 4.0.3 to the distibuted software to fix python-coveralls

### DIFF
--- a/coverage/build.bat
+++ b/coverage/build.bat
@@ -1,0 +1,16 @@
+%PYTHON% setup.py install --single-version-externally-managed --record record.txt
+
+:: Remove versioned entrypoints.
+%PYTHON% -c "import os; print('_'.join(os.environ['PY_VER'].split('.')[0]))" > temp.txt
+set /p PY_VER_MAJ=<temp.txt
+del temp.txt
+
+del %PREFIX%\Scripts\coverage%PY_VER_MAJ%-script.py
+del %PREFIX%\Scripts\coverage%PY_VER_MAJ%.exe
+del %PREFIX%\Scripts\coverage%PY_VER_MAJ%.exe.manifest
+
+del %PREFIX%\Scripts\coverage-%PY_VER%-script.py
+del %PREFIX%\Scripts\coverage-%PY_VER%.exe
+del %PREFIX%\Scripts\coverage-%PY_VER%.exe.manifest
+
+dir /s "%PREFIX%\Scripts\coverage*"

--- a/coverage/build.sh
+++ b/coverage/build.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+
+$PYTHON setup.py install --single-version-externally-managed --record record.txt
+
+# Remove versioned entrypoints.
+PY_VER_MAJ=$($PYTHON -c "import os; print('_'.join(os.environ['PY_VER'].split('.')[0]))")
+
+rm "${PREFIX}/bin/coverage${PY_VER_MAJ}"
+rm "${PREFIX}/bin/coverage-${PY_VER}"
+
+ls $PREFIX/bin/coverage*

--- a/coverage/meta.yaml
+++ b/coverage/meta.yaml
@@ -18,7 +18,6 @@ build:
 
 requirements:
   build:
-    - toolchain # [not osx or win]
     - python
     - setuptools
   run:

--- a/coverage/meta.yaml
+++ b/coverage/meta.yaml
@@ -1,0 +1,46 @@
+{% set version = "4.0.3" %}
+{% set hash = "c7d3db1882484022c81bf619be7b6365" %}
+{% set pkgname = "coverage" %}
+
+package:
+  name: {{ pkgname }}
+  version: {{ version }}
+
+source:
+  fn: {{ pkgname }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ pkgname[0] }}/{{ pkgname }}/{{ pkgname }}-{{ version }}.tar.gz
+  md5: {{ hash }}
+
+build:
+  number: 0
+  entry_points:
+    - coverage = coverage.cmdline:main
+
+requirements:
+  build:
+    - toolchain # [not osx or win]
+    - python
+    - setuptools
+  run:
+    - python
+
+test:
+  imports:
+    - coverage
+
+  commands:
+    - coverage --help
+
+about:
+  home: https://coverage.readthedocs.io
+  license: Apache 2.0
+  summary: 'Code coverage measurement for Python'
+
+extra:
+  recipe-maintainers:
+    - ericmjl
+    - jakirkham
+    - ocefpaf
+  copyright:
+    - Recipe modified from the conda forge feedstock for version 4.3.4 
+    - We build 4.0.3 to support python-coveralls on Python 3.6


### PR DESCRIPTION
Distributing coverage 4.0.3 with omnia to fix python-coveralls in python 3.6 since it is pinned to this version of coverage.