### PR TITLE
Fix the change conda-build made to the `noarch` property 

### DIFF
--- a/conda-build-all
+++ b/conda-build-all
@@ -219,10 +219,10 @@ def get_bldpkg_path(m, python, numpy):
     cfg.CONDA_NPY = int(numpy.replace('.', ''))
 
     m.config = cfg
-    if m.info_index()['subdir'] == 'noarch':
-        cfg.noarch = True
+    if m.info_index()['platform'] == 'noarch':
+        cfg.platform = 'noarch'
     else:
-        cfg.noarch = False
+        cfg.platform = m.info_index()['platform']
     # need to re-parse jinja2 in light of changing config vars.
     # (esp. for skip() to work)
     m.parse_again()

--- a/conda-build-all
+++ b/conda-build-all
@@ -219,10 +219,10 @@ def get_bldpkg_path(m, python, numpy):
     cfg.CONDA_NPY = int(numpy.replace('.', ''))
 
     m.config = cfg
-    if m.info_index()['platform'] == 'noarch':
-        cfg.platform = 'noarch'
-    else:
-        cfg.platform = m.info_index()['platform']
+    platform = m.info_index()['platform']
+    if platform is None:
+        platform = 'noarch'
+    cfg.platform = platform
     # need to re-parse jinja2 in light of changing config vars.
     # (esp. for skip() to work)
     m.parse_again()


### PR DESCRIPTION
...by setting the property it actually derives it from.

Fixes #735 

This only fixes the new problem. We still cannot use `noarch_python` in our builds as it breaks the string formatting, but that itself might also be fixed in a later version of conda-build.