### PR TITLE
Pin conda-build to 2.1.5 until they fix it

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -60,7 +60,7 @@ install:
   - conda config --add channels omnia
   - conda config --add channels salilab
   - conda update -yq --all
-  - conda install -yq conda-build jinja2 anaconda-client
+  - conda install -yq conda-build=2.1.5 jinja2 anaconda-client
   - powershell .\\devtools\\appveyor\\missing-headers.ps1
   # conda-build for some inane reason, effectively puts C:\cygwin\bin at the
   # front of the PATH, ahead of everything else, regardless. See

--- a/devtools/docker-build.sh
+++ b/devtools/docker-build.sh
@@ -11,7 +11,7 @@ curl -s -O https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
 bash Miniconda3-latest-Linux-x86_64.sh -b -p /anaconda
 PATH=/opt/rh/devtoolset-2/root/usr/bin:/anaconda/bin:$PATH
 conda config --add channels omnia
-conda install -yq conda-build jinja2 anaconda-client
+conda install -yq conda-build=2.1.5 jinja2 anaconda-client
 # Install missing LaTeX docs
 tlmgr install fncychap tabulary capt-of eqparbox environ trimspaces
 

--- a/devtools/osx-build.sh
+++ b/devtools/osx-build.sh
@@ -12,7 +12,7 @@ bash Miniconda3-latest-MacOSX-x86_64.sh -b -p $HOME/anaconda;
 export PATH=$HOME/anaconda/bin:$PATH;
 conda config --add channels omnia;
 conda config --show;
-conda install -yq conda-build jinja2 anaconda-client;
+conda install -yq conda-build=2.1.5 jinja2 anaconda-client;
 
 #export INSTALL_CUDA=`./conda-build-all --dry-run -- openmm`
 export INSTALL_OPENMM_PREREQUISITES=true


### PR DESCRIPTION
`--yes` and `--use-local` conflict in conda-build 2.1.6, no idea when it will be fixed, so pinning version to keep production moving