### PR TITLE
Added Libnetcdf and netcdf4 to the repo

### DIFF
--- a/coverage/meta.yaml
+++ b/coverage/meta.yaml
@@ -36,6 +36,8 @@ about:
   summary: 'Code coverage measurement for Python'
 
 extra:
+  omnia-md-recipe-maintainer:
+    - lnaden # Note: Not author of the recipe or source code
   recipe-maintainers:
     - ericmjl
     - jakirkham

--- a/libnetcdf/bld.bat
+++ b/libnetcdf/bld.bat
@@ -1,0 +1,20 @@
+mkdir %SRC_DIR%\build
+cd %SRC_DIR%\build
+
+cmake -G "NMake Makefiles" ^
+      -D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+      -D BUILD_SHARED_LIBS=ON ^
+      -D ENABLE_TESTS=OFF ^
+      -D ENABLE_HDF4=ON ^
+      -D CMAKE_PREFIX_PATH=%LIBRARY_PREFIX% ^
+      -D ZLIB_LIBRARY=%LIBRARY_LIB%\zlib.lib ^
+      -D ZLIB_INCLUDE_DIR=%LIBRARY_INC% ^
+      -D CMAKE_BUILD_TYPE=Release ^
+      %SRC_DIR%
+if errorlevel 1 exit 1
+
+nmake
+if errorlevel 1 exit 1
+
+nmake install
+if errorlevel 1 exit 1

--- a/libnetcdf/build.sh
+++ b/libnetcdf/build.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Build static.
+cmake -D CMAKE_INSTALL_PREFIX=$PREFIX \
+      -D CMAKE_INSTALL_LIBDIR:PATH=$PREFIX/lib \
+      -D ENABLE_DAP=ON \
+      -D ENABLE_HDF4=ON \
+      -D ENABLE_NETCDF_4=ON \
+      -D BUILD_SHARED_LIBS=OFF \
+      -D ENABLE_TESTS=OFF \
+      -D BUILD_UTILITIES=ON \
+      -D ENABLE_DOXYGEN=OFF \
+      -D ENABLE_LOGGING=ON \
+      $SRC_DIR
+make
+# ctest  # Run only for the shared lib build to save time.
+make install
+make clean
+
+# Build shared.
+cmake -D CMAKE_INSTALL_PREFIX=$PREFIX \
+      -D CMAKE_INSTALL_LIBDIR:PATH=$PREFIX/lib \
+      -D ENABLE_DAP=ON \
+      -D ENABLE_HDF4=ON \
+      -D ENABLE_NETCDF_4=ON \
+      -D BUILD_SHARED_LIBS=ON \
+      -D ENABLE_TESTS=OFF \
+      -D BUILD_UTILITIES=ON \
+      -D ENABLE_DOXYGEN=OFF \
+      -D ENABLE_LOGGING=ON \
+      $SRC_DIR
+make
+ctest
+make install

--- a/libnetcdf/dfile.c.patch
+++ b/libnetcdf/dfile.c.patch
@@ -1,0 +1,18 @@
+--- libdispatch\dfile.c.orig	2016-08-10 14:06:27.315735800 +1000
++++ libdispatch\dfile.c	2016-08-10 14:06:36.097008200 +1000
+@@ -166,6 +166,7 @@
+ 	{
+ 	    FILE *fp;
+ 	    size_t i;
++        __int64 file_len = 0;
+ #ifdef HAVE_SYS_STAT_H
+ 	    struct stat st;
+ #endif
+@@ -182,7 +183,6 @@
+
+         /* Windows and fstat have some issues, this will work around that. */
+ #ifdef HAVE_FILE_LENGTH_I64
+-        __int64 file_len = 0;
+         if((file_len = _filelengthi64(fileno(fp))) < 0) {
+           fclose(fp);
+           status = errno;

--- a/libnetcdf/dim.c.patch
+++ b/libnetcdf/dim.c.patch
@@ -1,0 +1,19 @@
+--- libsrc\dim.c.orig	2016-08-10 14:20:07.878295000 +1000
++++ libsrc\dim.c	2016-08-10 14:20:17.221986100 +1000
+@@ -444,6 +444,7 @@
+ 	int existid;
+ 	NC_dim *dimp;
+ 	char *newname;		/* normalized */
++    NC_string *old;
+
+ 	status = NC_check_id(ncid, &nc);
+ 	if(status != NC_NOERR)
+@@ -465,7 +466,7 @@
+ 	if(dimp == NULL)
+ 		return NC_EBADDIM;
+
+-	NC_string *old = dimp->name;
++	old = dimp->name;
+ 	newname = (char *)utf8proc_NFC((const unsigned char *)unewname);
+ 	if(newname == NULL)
+ 	    return NC_ENOMEM;

--- a/libnetcdf/meta.yaml
+++ b/libnetcdf/meta.yaml
@@ -1,0 +1,67 @@
+{% set version = "4.4.1.1" %}
+
+package:
+  name: libnetcdf
+  version: {{ version }}
+
+source:
+  fn: v{{ version }}.tar.gz
+  url: https://github.com/Unidata/netcdf-c/archive/v{{ version }}.tar.gz
+  sha256: 7f040a0542ed3f6d27f3002b074e509614e18d6c515b2005d1537fec01b24909
+  patches:
+    - dfile.c.patch  # [win]
+    - dim.c.patch  # [win]
+    - semantics.c.patch  # [win]
+
+build:
+  number: 2
+  features:
+    - vc9  # [win and py27]
+    - vc10  # [win and py34]
+    - vc14  # [win and py35]
+
+requirements:
+  build:
+    - python  # [win]
+    - cmake
+    - pkg-config  # [unix]
+    - msinttypes  # [win]
+    - curl
+    - zlib 1.2.*
+    - hdf4
+    - hdf5 1.8.17|1.8.17.*
+    - vc 9  # [win and py27]
+    - vc 10  # [win and py34]
+    - vc 14  # [win and py35]
+  run:
+    - curl
+    - zlib 1.2.*
+    - hdf4
+    - hdf5 1.8.17|1.8.17.*
+    - vc 9  # [win and py27]
+    - vc 10  # [win and py34]
+    - vc 14  # [win and py35]
+
+test:
+  commands:
+    - nc-config --all  # [unix]
+    - test -f ${PREFIX}/lib/libnetcdf.a  # [unix]
+    - test -f ${PREFIX}/lib/libnetcdf.so  # [linux]
+    - test -f ${PREFIX}/lib/libnetcdf.dylib  # [osx]
+    #- conda inspect linkages -p $PREFIX libnetcdf  # [not win]
+    #- conda inspect objects -p $PREFIX libnetcdf  # [osx]
+
+about:
+  home: http://www.unidata.ucar.edu/software/netcdf/
+  license: MIT
+  summary: 'Libraries and data formats that support array-oriented scientific data.'
+
+extra:
+  omnia-md-recipe-maintainer:
+    - lnaden # Note: Not author of the recipe or source code
+  recipe-maintainers:
+    - groutr
+    - ocefpaf
+    - kmuehlbauer
+  copyright:
+    - This is a copy of the conda-forge meta.yaml file. This package can be removed when we move to conda-forge

--- a/libnetcdf/run_test.sh
+++ b/libnetcdf/run_test.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+ncdump -h http://geoport-dev.whoi.edu/thredds/dodsC/estofs/atlantic

--- a/libnetcdf/semantics.c.patch
+++ b/libnetcdf/semantics.c.patch
@@ -1,0 +1,18 @@
+--- ncgen\semantics.c.orig	2016-11-23 16:47:45.538386400 +1000
++++ ncgen\semantics.c	2016-11-23 17:00:40.896820500 +1000
+@@ -601,6 +601,7 @@
+     int i;
+     int offset = 0;
+     unsigned long totaldimsize;
++    int largealign = 1;
+     if(tsym->touched) return;
+     tsym->touched=1;
+     switch (tsym->subclass) {
+@@ -637,7 +638,6 @@
+ 	    /* now compute the size of the compound based on*/
+ 	    /* what user specified*/
+ 	    offset = 0;
+-            int largealign = 1;
+             for(i=0;i<listlength(tsym->subnodes);i++) {
+               Symbol* field = (Symbol*)listget(tsym->subnodes,i);
+               /* only support 'c' alignment for now*/

--- a/mpich/meta.yaml
+++ b/mpich/meta.yaml
@@ -31,6 +31,8 @@ test:
         - tests/helloworld.f90
 
 extra:
+    omnia-md-recipe-maintainer:
+      - lnaden # Note: Not author of the recipe or source code
     recipe-maintainers:
         - astrofrog
         - bekozi

--- a/netcdf4/COPYING
+++ b/netcdf4/COPYING
@@ -1,0 +1,39 @@
+copyright: 2008 by Jeffrey Whitaker.
+
+Permission to use, copy, modify, and distribute this software and
+its documentation for any purpose and without fee is hereby granted,
+provided that the above copyright notice appear in all copies and that
+both the copyright notice and this permission notice appear in
+supporting documentation.
+
+THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE,
+INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO
+EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, INDIRECT OR
+CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF
+USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE.
+
+
+parts of pyiso8601 are included in netcdftime under the following license:
+
+Copyright (c) 2007 Michael Twomey
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/netcdf4/bld.bat
+++ b/netcdf4/bld.bat
@@ -1,0 +1,12 @@
+set SITECFG=%SRC_DIR%/setup.cfg
+
+echo [options] > %SITECFG%
+echo use_cython=True >> %SITECFG%
+echo [directories] >> %SITECFG%
+echo HDF5_libdir = %LIBRARY_LIB% >> %SITECFG%
+echo HDF5_incdir = %LIBRARY_INC% >> %SITECFG%
+echo netCDF4_libdir = %LIBRARY_LIB% >> %SITECFG%
+echo netCDF4_incdir = %LIBRARY_INC% >> %SITECFG%
+
+"%PYTHON%" setup.py install --single-version-externally-managed  --record record.txt
+if errorlevel 1 exit 1

--- a/netcdf4/build.sh
+++ b/netcdf4/build.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+if [[ $(uname) == Darwin ]]; then
+    export LDFLAGS="-headerpad_max_install_names $LDFLAGS"
+fi
+
+SETUPCFG=$SRC_DIR\setup.cfg
+
+echo "[options]" > $SETUPCFG
+echo "use_cython=True" >> $SETUPCFG
+echo "[directories]" >> $SETUPCFG
+echo "netCDF4_dir = $PREFIX" >> $SETUPCFG
+
+${PYTHON} setup.py install --single-version-externally-managed --record record.txt

--- a/netcdf4/meta.yaml
+++ b/netcdf4/meta.yaml
@@ -1,0 +1,61 @@
+{% set version = "1.2.7" %}
+
+package:
+  name: netcdf4
+  version: {{ version }}
+
+source:
+  fn: netCDF4-{{ version }}.tar.gz
+  url: https://github.com/Unidata/netcdf4-python/archive/v{{ version }}rel.tar.gz
+  sha256: 42255f15341ae1959f814443385af4be5ae012b42e2202f300a5e5095338f54e
+
+build:
+  number: 0
+  entry_points:
+    - ncinfo = netCDF4.utils:ncinfo
+    - nc4tonc3 = netCDF4.utils:nc4tonc3
+    - nc3tonc4 = netCDF4.utils:nc3tonc4
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - numpy x.x
+    - cython
+    - hdf5 1.8.17|1.8.17.*
+    - libnetcdf 4.4.*
+  run:
+    - python
+    - setuptools
+    - numpy x.x
+    - hdf5 1.8.17|1.8.17.*
+    - libnetcdf 4.4.*
+
+test:
+  imports:
+    - netCDF4
+    - netcdftime
+  commands:
+    - ncinfo -h
+    - nc4tonc3 -h
+    - nc3tonc4 -h
+    - conda inspect linkages -p $PREFIX netcdf4  # [not win]
+    - conda inspect objects -p $PREFIX netcdf4  # [osx]
+
+about:
+  home: http://github.com/Unidata/netcdf4-python
+  license: OSI Approved and MIT
+  license_file: '{{ environ["RECIPE_DIR"] }}/COPYING'
+  summary: 'Provides an object-oriented python interface to the netCDF version 4 library.'
+  dev_url: https://github.com/Unidata/netcdf4-python
+  doc_url: https://unidata.github.io/netcdf4-python
+
+extra:
+  omnia-md-recipe-maintainer:
+    - lnaden # Note: Not author of the recipe or source code
+  recipe-maintainers:
+    - ocefpaf
+    - pelson
+    - dopplershift
+  copyright:
+    - This is a copy of the conda-forge meta.yaml file. This package can be removed when we move to conda-forge

--- a/netcdf4/run_test.py
+++ b/netcdf4/run_test.py
@@ -1,0 +1,8 @@
+import netCDF4
+
+# OPeNDAP.
+url = 'http://geoport-dev.whoi.edu/thredds/dodsC/estofs/atlantic'
+nc = netCDF4.Dataset(url)
+
+# Compiled with cython.
+assert nc.filepath() == url


### PR DESCRIPTION
Omnia packages which depend on it will downgrade/fall behind the longer we are not on conda-forge.
I have added these 2 packages to help keep some of our packages up to date.

Additionally added some `extra` information on other packages I personally have added to make it clear who the point-of-contact should be (me) for the builds as they exist on omnia.