### PR TITLE
Update Lomap recepie. PyQt4 is needed

### DIFF
--- a/lomap/meta.yaml
+++ b/lomap/meta.yaml
@@ -4,7 +4,7 @@ package:
 
 source:
   git_rev: 0.0.0
-  git_url: https://github.com/nividic/Lomap.git
+  git_url: https://github.com/MobleyLab/Lomap.git
 
 
 build:
@@ -18,7 +18,7 @@ requirements:
     - boost ==1.61
     - rdkit
     - matplotlib
-    - pyqt
+    - pyqt ==4.11.4
     - networkx >=1.11
     - graphviz
     - pygraphviz
@@ -29,7 +29,7 @@ requirements:
     - boost ==1.61
     - rdkit 
     - matplotlib
-    - pyqt
+    - pyqt ==4.11.4
     - networkx
     - graphviz
     - pygraphviz


### PR DESCRIPTION
I updated the PyQt version required and the new Lomap git home page  