### PR TITLE
Remove parmed dependence on openmm

### DIFF
--- a/parmed/meta.yaml
+++ b/parmed/meta.yaml
@@ -7,7 +7,7 @@ source:
   url: https://github.com/ParmEd/ParmEd/archive/2.7.3.tar.gz
   
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:

--- a/parmed/meta.yaml
+++ b/parmed/meta.yaml
@@ -19,7 +19,6 @@ requirements:
     - python
     - numpy
     - pandas
-    - openmm
 
 about:
   home: http://parmed.github.io/ParmEd


### PR DESCRIPTION
Since openmm is an optional dependency of parmed, can we remove the dependency?

We are deploying our own versions of openmm and meld built against specific cuda versions. Installing parmed from the omnia channel tries to pull in openmm, which leads to a conflict.