### PR TITLE
Make conda-forge highest priority channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,6 @@ then, we thank you for your patience as we go through this transition.
 Python packages are built against latest two releases of python (3.5 and 3.6) and python 2.7.
 Packages which have a binary dependency on [numpy](http://www.numpy.org/) are built against the latest two releases of numpy (1.10 and 1.11).
 
-**WARNING: Python 3.4 support will be phased out now that python 3.6 has been released.**
-
 **WARNING: Numpy 1.09 support will be phased out now that numpy 1.11 has been released.**
 
 ### Building the packages

--- a/README.md
+++ b/README.md
@@ -12,26 +12,24 @@ These packages also depend on the `conda-forge` conda channel.
 
 To install a package (`mdtraj` for example)
 ```bash
-# Set the channel priority behavior
-conda config --set channel_priority false
-# Add conda-forge and omnia to your channel list
-conda config --add channels conda-forge --add channels omnia
+# Add conda-forge and omnia to your channel list, one time action
+conda config --add channels omnia --add channels conda-forge
 # Install the 'mdtraj' a package
 conda install mdtraj
 ```
 
-The `channel_priority` behavior we configure gives priority to the highest version of the package over all channels.
- 
-The default behavior (`channel_priority true`) pulls packages from the highest priority chanel, independent of package 
-version numbers. An older version package on a higher priority channel will be installed over a newer version 
-of the same package on a lower priority channel.
+To install a package in one line:
+```bash
+# channels searched in order they are added here
+conda install -c conda-forge -c omnia mdtraj
+``` 
 
-### Important: Channel priority behavior must be disabled for `omnia` to work!
+When setting up the configuration through `conda config`, the channels are added to the top of the search priority 
+sequentially. So `conda config --add channels omnia --add channels conda-forge` first adds `omnia` to the top of the 
+list, then adds `conda-forge` on top of that, giving `conda-forge` the highest priority.
 
-These packages must use the old style of conda channel priority until omnia is entirely on conda-forge!
-The instructions below enforce the old channel priority format, please visit 
-[the conda documentations on channel priority](https://conda.io/docs/channels.html) 
-for more information.
+When temporarily searching through channels with `conda install`, the channels are prioritized in the order they 
+are provided. So `conda install -c conda-forge -c omnia` prioritizes `conda-forge` first, then `omnia`. 
 
 ## Migration to conda-forge
 The Omnia project has started migrating to [`conda-forge`](https://conda-forge.github.io/). New packages that 
@@ -40,18 +38,19 @@ The Omnia project has started migrating to [`conda-forge`](https://conda-forge.g
 
 ### Planed Migration Stages
 
-1. (**Current**) Update build image to CentOS 6 from CentOS 5
+1. Update build image to CentOS 6 from CentOS 5
 
     The base Docker image for linux builds will be updated to CentOS 6 with its new glibc. The base image is the 
     `conda-forge` anvil, with some [custom addons](https://hub.docker.com/r/jchodera/omnia-linux-anvil/~/dockerfile/) 
     to include things like the AMD SDK, TexLive, and CUDA for GPU builds. The updated version will ensure packages 
     can work on the `conda-forge` platform which is CentOS 6 based.
     
-1. For packages that appear in `conda-forge`, remove the corresponding recipes in `omnia`
+1. (**Current**) For packages that appear in `conda-forge`, remove the corresponding recipes in `omnia`
 
     We want to minimize the amount of work we have to do as maintainers. To that end, we will stop building things 
     which freely appear on `conda-forge` and maintained by someone other than us!
-    For reproducibility purposes, we will keep our previously compiled versions, but they will not longer be updated.  
+    For reproducibility purposes, we will keep our previously compiled versions, but they will not longer be updated.
+    * Developers: if you want users to still exclusivley use the `omnia` conda channel, please see the **Copying from conda-forge** section below 
      
 1. Allow recipes that do not depend on OpenMM to migrate from omnia to conda-forge
 
@@ -79,6 +78,37 @@ The Omnia project has started migrating to [`conda-forge`](https://conda-forge.g
 ### How to migrate to `conda-forge` (for existing packages)
 
 PLACEHOLDER
+
+### Copying from Conda Forge
+
+It can be a bit confusing to rely on two conda channels where the order they are specified in changes which version of 
+packages are installed. During the migration to `conda-forge`, developers can copy their binary tarballs from 
+`conda-forge` to the `omnia` channel using the Anaconda Cloud API, allowing users to rely only on the `omnia` channel. 
+There are a couple conditions for this though:
+
+* Packages still built in `omnia` will search for dependencies in `conda-forge` then `omnia`, in that order
+* Your package should **not** depend on packages which only exist in `omnia` 
+* You the developer will be responsible for also copying any dependencies from `conda-forge` to `omnia` that you need and are not on the default channel
+
+To copy packages:
+
+**If you have write access to the `omnia` cloud**
+1. **Open an Issue**
+    * This is important so we can track changes made to the cloud in a public space
+    * Note which package, version, and any dependencies you are bringing over
+1. Get the [Anaconda CLI Tool](https://docs.continuum.io/anaconda-cloud/using#packages)
+1. Copy the package [with the CLI](https://docs.continuum.io/anaconda-cloud/cli) 
+    * `anaconda copy conda-forge/{PACKAGE}/{VERSION} --to-owner omnia`
+    * Replace `{PACKAGE}` and `{VERSION}` accordingly
+1. Copy any dependencies you need in the same way 
+1. Close the issue
+
+**If you do NOT have cloud write access**
+1. Open an issue, request which package and dependencies
+1. Request a maintainer who has cloud write access follow the steps above.
+
+Eventually, all packages will be on `conda-forge` and we won't have to worry about the multiple channels any more, until 
+then, we thank you for your patience as we go through this transition.
 
 ### Supported versions
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -60,7 +60,7 @@ install:
   - conda update -yq --all
   - conda config --add channels omnia
   - conda config --add channels conda-forge
-  - conda install -yq conda-build jinja2 anaconda-client
+  - conda install -yq conda\>=4.3 conda-build jinja2 anaconda-client
   - powershell .\\devtools\\appveyor\\missing-headers.ps1
   # conda-build for some inane reason, effectively puts C:\cygwin\bin at the
   # front of the PATH, ahead of everything else, regardless. See

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,15 +26,6 @@ environment:
       PYTHON_ARCH: "64"
 
     - PYTHON: "C:\\Miniconda3"
-      CONDA_PY: "34"
-      PYTHON_VERSION: "3.4.x"
-      PYTHON_ARCH: "32"
-    - PYTHON: "C:\\Miniconda3-x64"
-      CONDA_PY: "34"
-      PYTHON_VERSION: "3.4.x"
-      PYTHON_ARCH: "64"
-
-    - PYTHON: "C:\\Miniconda3"
       CONDA_PY: "35"
       PYTHON_VERSION: "3.5.x"
       PYTHON_ARCH: "32"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -60,7 +60,7 @@ install:
   - conda update -yq --all
   - conda config --add channels omnia
   - conda config --add channels conda-forge
-  - conda install -yq conda\>=4.3 conda-build jinja2 anaconda-client
+  - conda install -yq conda>=4.3 conda-build jinja2 anaconda-client
   - powershell .\\devtools\\appveyor\\missing-headers.ps1
   # conda-build for some inane reason, effectively puts C:\cygwin\bin at the
   # front of the PATH, ahead of everything else, regardless. See

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -58,9 +58,9 @@ install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
   - set PATH=C:\MinGW\msys\1.0\bin;%PATH%
   - conda update -yq --all
+  - conda install -yq conda-build jinja2 anaconda-client
   - conda config --add channels omnia
   - conda config --add channels conda-forge
-  - conda install -yq conda>=4.3 conda-build jinja2 anaconda-client
   - powershell .\\devtools\\appveyor\\missing-headers.ps1
   # conda-build for some inane reason, effectively puts C:\cygwin\bin at the
   # front of the PATH, ahead of everything else, regardless. See

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -58,9 +58,8 @@ install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
   - set PATH=C:\MinGW\msys\1.0\bin;%PATH%
   - conda update -yq --all
-  - conda config --set channel_priority false
-  - conda config --add channels conda-forge
   - conda config --add channels omnia
+  - conda config --add channels conda-forge
   - conda install -yq conda-build jinja2 anaconda-client
   - powershell .\\devtools\\appveyor\\missing-headers.ps1
   # conda-build for some inane reason, effectively puts C:\cygwin\bin at the

--- a/conda-build-all
+++ b/conda-build-all
@@ -95,7 +95,7 @@ def main():
         '--python',
         help="Set the Python version used by conda build",
         metavar="PYTHON_VER",
-        default='27,34,35,36',
+        default='27,35,36',
 
     )
     p.add_argument(
@@ -346,19 +346,6 @@ def required_builds(metadatas, pythons, numpys, channel_urls, verbose,
                         numpy = numpy_iter[1]
                         if verbose > 1:
                             print("Attempting to build {pkgname} on Python 3.6 and NumPy {numpy}".format(
-                                pkgname=base_bldpkg_path, numpy=numpy))
-                        rebuild_paths = True
-                if python == "34" and numpy == "1.12":
-                    if verbose > 1:
-                        print("{pkgname} will not build on Python 3.4 and NumPy 1.12".format(pkgname=base_bldpkg_path))
-                    # Check if there are more numpy versions coming:
-                    if len(numpy_iter) == len(numpy_iter.versions):
-                        continue
-                    else:
-                        # Try a lower numpy version
-                        numpy = numpy_iter[-2]
-                        if verbose > 1:
-                            print("Attempting to build {pkgname} on Python 3.4 and NumPy {numpy}".format(
                                 pkgname=base_bldpkg_path, numpy=numpy))
                         rebuild_paths = True
                 if rebuild_paths:

--- a/devtools/docker-build.sh
+++ b/devtools/docker-build.sh
@@ -5,7 +5,7 @@ conda config --add channels omnia
 # Move the conda-forge channel to the top
 # Cannot just append omnia otherwise default would have higher priority
 conda config --add channels conda-forge
-conda install -yq conda-build jinja2 anaconda-client
+conda install -yq conda\>=4.3 conda-build jinja2 anaconda-client
 
 /io/conda-build-all -vvv $UPLOAD -- /io/*
 

--- a/devtools/docker-build.sh
+++ b/devtools/docker-build.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 set -e
 set -x
-conda config --set channel_priority false
 conda config --add channels omnia
+# Move the conda-forge channel to the top
+# Cannot just append omnia otherwise default would have higher priority
+conda config --add channels conda-forge
 conda install -yq conda-build jinja2 anaconda-client
 
 /io/conda-build-all -vvv $UPLOAD -- /io/*

--- a/devtools/osx-build.sh
+++ b/devtools/osx-build.sh
@@ -12,7 +12,7 @@ bash Miniconda3-latest-MacOSX-x86_64.sh -b -p $HOME/anaconda;
 export PATH=$HOME/anaconda/bin:$PATH;
 conda config --add channels omnia;
 conda config --add channels conda-forge;
-conda install -yq conda conda-env conda-build jinja2 anaconda-client;
+conda install -yq conda\>=4.3 conda-env conda-build jinja2 anaconda-client;
 conda config --show;
 
 # Do this step last to make sure conda-build, conda-env, and conda updates come from the same channel first

--- a/devtools/osx-build.sh
+++ b/devtools/osx-build.sh
@@ -10,10 +10,9 @@ brew tap -y caskroom/cask
 curl -s -O https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh;
 bash Miniconda3-latest-MacOSX-x86_64.sh -b -p $HOME/anaconda;
 export PATH=$HOME/anaconda/bin:$PATH;
-conda install -yq conda conda-env conda-build jinja2 anaconda-client;
-conda config --set channel_priority false;
-conda config --add channels conda-forge;
 conda config --add channels omnia;
+conda config --add channels conda-forge;
+conda install -yq conda conda-env conda-build jinja2 anaconda-client;
 conda config --show;
 
 # Do this step last to make sure conda-build, conda-env, and conda updates come from the same channel first


### PR DESCRIPTION
* Made conda-forge top priority channel, omnia second
* Removed --no-chan-pri requirement
* Updated README to reflect changes
* Added "How to keep using only omnia" info to README
* Drops support for Python 3.4

xref: https://github.com/omnia-md/conda-recipes/pull/772#issuecomment-303382780
xref: #777, conda-forge/staged-recipes#3020