### PR TITLE
[openforcefield] 0.0.2-1: fix for conda-forge

### DIFF
--- a/openforcefield/meta.yaml
+++ b/openforcefield/meta.yaml
@@ -8,7 +8,7 @@ source:
 
 build:
   preserve_egg_dir: True
-  number: 0
+  number: 1
   skip: True # [win]
 
 requirements:
@@ -22,6 +22,7 @@ requirements:
     - numpy
     - networkx
     - lxml
+    - icu 58*  # This is a lxml dependency but sometimes conda installs version 56
     - openmoltools >=0.7.3
     - parmed
     - matplotlib


### PR DESCRIPTION
With the `conda-forge` channel, sometimes `conda` installs `icu 56` (a dependency of `lxml`) and causes problems (`lxml` was build with `icu 58`). See open-forcefield-group/openforcefield#44.

This just bumps build number.