### PR TITLE
-y option no longer valid in homebrew-cask?

### DIFF
--- a/devtools/osx-build.sh
+++ b/devtools/osx-build.sh
@@ -31,7 +31,7 @@ if [ "$INSTALL_OPENMM_PREREQUISITES" = true ] ; then
     rm -f cuda_mac_installer_tk.tar.gz cuda_mac_installer_drv.tar.gz
 
     # Install latex.
-    brew cask install -y basictex
+    brew cask install -y basictex || brew cask install basictex
     export PATH="/usr/texbin:${PATH}:/usr/bin"
     sudo tlmgr update --self
     sleep 5

--- a/devtools/osx-build.sh
+++ b/devtools/osx-build.sh
@@ -31,8 +31,17 @@ if [ "$INSTALL_OPENMM_PREREQUISITES" = true ] ; then
     rm -f cuda_mac_installer_tk.tar.gz cuda_mac_installer_drv.tar.gz
 
     # Install latex.
-    brew cask install -y basictex || brew cask install basictex
     export PATH="/usr/texbin:${PATH}:/usr/bin"
+    if brew cask install -y basictex
+    then
+        # Do nothing if the command completed
+        true
+    else
+        # Trap the error and install using new version
+        brew cask install basictex
+        # Path based on https://github.com/caskroom/homebrew-cask/blob/master/Casks/basictex.rb location
+        export PATH="/usr/local/texlive/*basic/bin/*/:${PATH}"
+    fi
     sudo tlmgr update --self
     sleep 5
     sudo tlmgr --persistent-downloads install titlesec framed threeparttable wrapfig multirow collection-fontsrecommended hyphenat xstring \

--- a/devtools/osx-build.sh
+++ b/devtools/osx-build.sh
@@ -39,6 +39,7 @@ if [ "$INSTALL_OPENMM_PREREQUISITES" = true ] ; then
     else
         # Trap the error and install using new version
         brew cask install basictex
+        mkdir -p /usr/texbin
         # Path based on https://github.com/caskroom/homebrew-cask/blob/master/Casks/basictex.rb location
         # .../texlive/{YEAR}basic/bin/{ARCH}/{Location of actual binaries}
         # Sym link them to the /usr/texbin folder in the path

--- a/devtools/osx-build.sh
+++ b/devtools/osx-build.sh
@@ -40,7 +40,9 @@ if [ "$INSTALL_OPENMM_PREREQUISITES" = true ] ; then
         # Trap the error and install using new version
         brew cask install basictex
         # Path based on https://github.com/caskroom/homebrew-cask/blob/master/Casks/basictex.rb location
-        export PATH="/usr/local/texlive/*basic/bin/*/:${PATH}"
+        # .../texlive/{YEAR}basic/bin/{ARCH}/{Location of actual binaries}
+        # Sym link them to the /usr/texbin folder in the path
+        ln -s /usr/local/texlive/*basic/bin/*/* /usr/texbin/
     fi
     sudo tlmgr update --self
     sleep 5


### PR DESCRIPTION
Not sure what is wrong here, but something changed either in Homebrew or Homebrew-cask that made it so the -y option isnot accepted in `brew cask` anymore. I don't know if this is a bug or intentional yet and no one has raised an issue on either github, so I am writting in a || to try and error trap a bit for both cases.