### PR TITLE
Pin Windows to Conda-build 2.1.17

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -49,7 +49,7 @@ install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
   - set PATH=C:\MinGW\msys\1.0\bin;%PATH%
   - conda update -yq --all
-  - conda install -yq conda-build jinja2 anaconda-client
+  - conda install -yq conda-build==2.1.17 jinja2 anaconda-client
   - conda config --add channels omnia
   - conda config --add channels conda-forge
   - powershell .\\devtools\\appveyor\\missing-headers.ps1


### PR DESCRIPTION
Fixes #797
More of a work-around, but doing a full upgrade of conda-build may require much more work