### PR TITLE
Remove de-optimizing OpenMM CXX Flags

### DIFF
--- a/openmm/build.sh
+++ b/openmm/build.sh
@@ -25,12 +25,7 @@ if [[ "$OSTYPE" == "linux-gnu" ]]; then
 
     # OpenMM build configuration
     CUDA_PATH="/usr/local/cuda-${CUDA_VERSION}"
-    CMAKE_FLAGS+=" -DCUDA_CUDART_LIBRARY=${CUDA_PATH}/lib64/libcudart.so"
-    CMAKE_FLAGS+=" -DCUDA_NVCC_EXECUTABLE=${CUDA_PATH}/bin/nvcc"
-    CMAKE_FLAGS+=" -DCUDA_SDK_ROOT_DIR=${CUDA_PATH}/"
-    CMAKE_FLAGS+=" -DCUDA_TOOLKIT_INCLUDE=${CUDA_PATH}/include"
     CMAKE_FLAGS+=" -DCUDA_TOOLKIT_ROOT_DIR=${CUDA_PATH}/"
-    CMAKE_FLAGS+=" -DCMAKE_CXX_FLAGS_RELEASE=-I/usr/include/nvidia/"
     # AMD APP SDK 3.0 OpenCL
     CMAKE_FLAGS+=" -DOPENCL_INCLUDE_DIR=/opt/AMDAPPSDK-3.0/include/"
     CMAKE_FLAGS+=" -DOPENCL_LIBRARY=/opt/AMDAPPSDK-3.0/lib/x86_64/libOpenCL.so"
@@ -43,7 +38,6 @@ elif [[ "$OSTYPE" == "darwin"* ]]; then
     export MACOSX_DEPLOYMENT_TARGET="10.9"
     CMAKE_FLAGS+=" -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++"
     CMAKE_FLAGS+=" -DCMAKE_OSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET}"
-    CMAKE_FLAGS+=" -DCUDA_SDK_ROOT_DIR=/Developer/NVIDIA/CUDA-${CUDA_VERSION}"
     CMAKE_FLAGS+=" -DCUDA_TOOLKIT_ROOT_DIR=/Developer/NVIDIA/CUDA-${CUDA_VERSION}"
     CMAKE_FLAGS+=" -DCMAKE_OSX_SYSROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX${MACOSX_DEPLOYMENT_TARGET}.sdk"
 fi

--- a/openmm/meta.yaml
+++ b/openmm/meta.yaml
@@ -8,7 +8,7 @@ source:
 
 
 build:
-  number: 1
+  number: 0
   skip: True # [win]
 
 extra:

--- a/openmm/meta.yaml
+++ b/openmm/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     # on osx, need to install doxygen manually
     - doxygen   [not osx]
     # for building docs
-    - sphinx
+    - sphinx ==1.5.6
     - sphinxcontrib-bibtex
     - sphinxcontrib-lunrsearch
     - sphinxcontrib-autodoc_doxygen

--- a/openmm/meta.yaml
+++ b/openmm/meta.yaml
@@ -8,7 +8,7 @@ source:
 
 
 build:
-  number: 0
+  number: 1
   skip: True # [win]
 
 extra:


### PR DESCRIPTION
The `-DCMAKE` flags for OpenMM were redundant and causing optimization flags to not be set. This PR should fix this problem.

We have to trigger a new OpenMM build because of this setting. Will only affect the Unix based builds.

We're doing testing in the conda-dev-recipes repo right now to make sure this change has the desired affect first, this PR is in anticipation right now to run through the tests.

See discussion in pandegroup/openmm#1869 and omnia-md/conda-dev-recipes#107 for more details