### PR TITLE
[openforcefield] Pin networkx to 1.11 to avoid API-breaking 2.0

### DIFF
--- a/openforcefield/meta.yaml
+++ b/openforcefield/meta.yaml
@@ -20,7 +20,7 @@ requirements:
   run:
     - python
     - numpy
-    - networkx
+    - networkx ==1.11
     - lxml
     - icu 58*  # This is a lxml dependency but sometimes conda installs version 56
     - openmoltools >=0.7.3


### PR DESCRIPTION
Fixes https://github.com/open-forcefield-group/openforcefield/issues/63