### PR TITLE
Split Travis builds by Python version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,10 @@ services:
   - docker
 
 env:
+  matrix:
+    - PY_BUILD_VERSION="27"
+    - PY_BUILD_VERSION="35"
+    - PY_BUILD_VERSION="36"
   global:
     - CUDA_VERSION: "8.0"
     - CUDA_SHORT_VERSION: "80"
@@ -36,7 +40,7 @@ script:
 
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
 
-        docker run -e UPLOAD -e BINSTAR_TOKEN -e TRAVIS_PULL_REQUEST
+        docker run -e UPLOAD -e BINSTAR_TOKEN -e TRAVIS_PULL_REQUEST -e PY_BUILD_VERSION
             -t -i --rm -v `pwd`:/io jchodera/omnia-linux-anvil:texlive-amd30-cuda${CUDA_SHORT_VERSION}
             bash /io/devtools/docker-build.sh;
 

--- a/devtools/docker-build.sh
+++ b/devtools/docker-build.sh
@@ -8,6 +8,6 @@ conda config --add channels conda-forge
 conda update -yq conda
 conda install -yq conda-build==2.1.17 jinja2 anaconda-client
 
-/io/conda-build-all -vvv $UPLOAD -- /io/*
+/io/conda-build-all -vvv --python $PY_BUILD_VERSION $UPLOAD -- /io/*
 
 #mv /anaconda/conda-bld/linux-64/*tar.bz2 /io/ || true

--- a/devtools/osx-build.sh
+++ b/devtools/osx-build.sh
@@ -48,4 +48,4 @@ if [ "$INSTALL_OPENMM_PREREQUISITES" = true ] ; then
 fi;
 
 # Build packages
-./conda-build-all -v $UPLOAD -- *
+./conda-build-all -vvv --python $PY_BUILD_VERSION $UPLOAD -- *


### PR DESCRIPTION
We previously had all python versions of our packages building on a single job, this PR proposes to split up the python versions to separate jobs on Travis. [The dev repo](https://github.com/omnia-md/conda-dev-recipes/pull/81) has had this feature for a while now and I think its worth considering for here. There are up and downsides so I would like some feedback and opinions.

Pros:
* Reduces odds of a timeout due to multiple versions being built in the same job
* Easier debugging of specific versions
* Likely faster total build times in linux and *maybe OSX*

Cons:
* Adds more jobs which must run, jobs may delay startup of each other since Travis has a concurrent job limit
* Each job has to pull down the docker image, slower cumulative start time, but can be done in parallel so wall clock will be faster (limited by previous point)
* OSX Builds may actually take longer in Wall Clock time because Travis OSX builds are often backlogged due to total global requests.

Thoughts and opinions?