### PR TITLE
Enable python 3 builds on win64 for saltswap

### DIFF
--- a/saltswap/meta.yaml
+++ b/saltswap/meta.yaml
@@ -9,7 +9,7 @@ source:
 build:
   preserve_egg_dir: True
   number: 0
-  skip: True  # [win]
+  skip: True # [win32 or (win and py2k)
 
 requirements:
   build:


### PR DESCRIPTION
This still needed to be added before the premature merge of #823 .