### PR TITLE
Cache the Nvidia drivers on OSX to speed boot time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ cache:
   directories:
     - $HOME/Library/Caches/Homebrew
     - $HOME/nvidia_cache
+  # https://docs.travis-ci.com/user/caching/#Setting-the-timeout
+  timeout: 900  # seconds: 15 min cache upload time (default is 3 min)
 
 language: c
 sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,11 @@ os:
 # See also: https://blog.travis-ci.com/2016-10-04-osx-73-default-image-live/
 osx_image: xcode6.4
 
+cache:
+  directories:
+    - $HOME/Library/Caches/Homebrew/
+    - $HOME/nvidia_cache
+
 language: c
 sudo: required
 
@@ -42,5 +47,6 @@ script:
 
     elif [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
         echo "Building osx...";
+        export NVIDIA_CACHE=$HOME/nvidia_cache;
         bash devtools/osx-build.sh;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ osx_image: xcode6.4
 
 cache:
   directories:
-    - $HOME/Library/Caches/Homebrew/
+    - $HOME/Library/Caches/Homebrew
     - $HOME/nvidia_cache
 
 language: c

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ osx_image: xcode6.4
 
 cache:
   directories:
-    - $HOME/Library/Caches/Homebrew
+    # Disabled homebrew cache, did not appear to do anything
+    #- $HOME/Library/Caches/Homebrew
     - $HOME/nvidia_cache
   # https://docs.travis-ci.com/user/caching/#Setting-the-timeout
   timeout: 900  # seconds: 15 min cache upload time (default is 3 min)

--- a/devtools/osx-build.sh
+++ b/devtools/osx-build.sh
@@ -32,6 +32,7 @@ if [ "$INSTALL_OPENMM_PREREQUISITES" = true ] ; then
         cd $NVIDIA_CACHE
         curl -O -# http://developer.download.nvidia.com/compute/cuda/${CUDA_VERSION}/Prod/network_installers/mac/x86_64/cuda_mac_installer_tk.tar.gz
         curl -O -# http://developer.download.nvidia.com/compute/cuda/${CUDA_VERSION}/Prod/network_installers/mac/x86_64/cuda_mac_installer_drv.tar.gz
+    fi
     sudo tar -zxf cuda_mac_installer_tk.tar.gz -C /;
     sudo tar -zxf cuda_mac_installer_drv.tar.gz -C /;
     # Don't delete the tarballs for now because the N

--- a/devtools/osx-build.sh
+++ b/devtools/osx-build.sh
@@ -3,8 +3,8 @@ set -e -x
 export MACOSX_DEPLOYMENT_TARGET="10.9"
 # Clear existing locks
 rm -rf /usr/local/var/homebrew/locks
-# Update homebrew (uses cache if available)
-brew update -y --quiet
+# Update homebrew (Disabled for test until cache figured out)
+#brew update -y --quiet
 
 # Install Miniconda
 curl -s -O https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh;

--- a/devtools/osx-build.sh
+++ b/devtools/osx-build.sh
@@ -3,8 +3,8 @@ set -e -x
 export MACOSX_DEPLOYMENT_TARGET="10.9"
 # Clear existing locks
 rm -rf /usr/local/var/homebrew/locks
-# Update homebrew (Disabled for test until cache figured out)
-#brew update -y --quiet
+# Update homebrew cant disable this yet, -y and --quiet do nothing
+brew update
 
 # Install Miniconda
 curl -s -O https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh;

--- a/devtools/osx-build.sh
+++ b/devtools/osx-build.sh
@@ -1,13 +1,10 @@
 #!/bin/bash
 set -e -x
 export MACOSX_DEPLOYMENT_TARGET="10.9"
-# Update homebrew
 # Clear existing locks
 rm -rf /usr/local/var/homebrew/locks
 # Update homebrew (uses cache if available)
-#brew uninstall -y brew-cask || brew untap -y caskroom/cask || 1
 brew update -y --quiet
-#brew tap -y caskroom/cask
 
 # Install Miniconda
 curl -s -O https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh;

--- a/devtools/osx-build.sh
+++ b/devtools/osx-build.sh
@@ -5,9 +5,9 @@ export MACOSX_DEPLOYMENT_TARGET="10.9"
 # Clear existing locks
 rm -rf /usr/local/var/homebrew/locks
 # Update homebrew (uses cache if available)
-brew uninstall -y brew-cask || brew untap -y caskroom/cask || 1
+#brew uninstall -y brew-cask || brew untap -y caskroom/cask || 1
 brew update -y --quiet
-brew tap -y caskroom/cask
+#brew tap -y caskroom/cask
 
 # Install Miniconda
 curl -s -O https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh;
@@ -28,12 +28,14 @@ if [ "$INSTALL_OPENMM_PREREQUISITES" = true ] ; then
     # Install OpenMM dependencies that can't be installed through
     # conda package manager (doxygen + CUDA)
     brew install -y https://raw.githubusercontent.com/Homebrew/homebrew-core/5b680fb58fedfb00cd07a7f69f5a621bb9240f3b/Formula/doxygen.rb
-    if [ -d "$NVIDIA_CACHE" ]; then
-        cd $NVIDIA_CACHE
-    else
-        mkdir -p $NVIDIA_CACHE
-        cd $NVIDIA_CACHE
+    # Make the nvidia-cache if not there
+    mkdir -p $NVIDIA_CACHE
+    cd $NVIDIA_CACHE
+    # Download missing nvidia installers
+    if ! [ -f cuda_mac_installer_tk.tar.gz ]; then
         curl -O -# http://developer.download.nvidia.com/compute/cuda/${CUDA_VERSION}/Prod/network_installers/mac/x86_64/cuda_mac_installer_tk.tar.gz
+    fi
+    if ! [ -f cuda_mac_installer_drv.tar.gz ]; then
         curl -O -# http://developer.download.nvidia.com/compute/cuda/${CUDA_VERSION}/Prod/network_installers/mac/x86_64/cuda_mac_installer_drv.tar.gz
     fi
     sudo tar -zxf cuda_mac_installer_tk.tar.gz -C /;

--- a/devtools/osx-build.sh
+++ b/devtools/osx-build.sh
@@ -25,11 +25,19 @@ if [ "$INSTALL_OPENMM_PREREQUISITES" = true ] ; then
     # Install OpenMM dependencies that can't be installed through
     # conda package manager (doxygen + CUDA)
     brew install -y https://raw.githubusercontent.com/Homebrew/homebrew-core/5b680fb58fedfb00cd07a7f69f5a621bb9240f3b/Formula/doxygen.rb
-    curl -O -# http://developer.download.nvidia.com/compute/cuda/${CUDA_VERSION}/Prod/network_installers/mac/x86_64/cuda_mac_installer_tk.tar.gz
-    curl -O -# http://developer.download.nvidia.com/compute/cuda/${CUDA_VERSION}/Prod/network_installers/mac/x86_64/cuda_mac_installer_drv.tar.gz
+    if [ -d "$NVIDIA_CACHE" ]; then
+        cd $NVIDIA_CACHE
+    else
+        mkdir -p $NVIDIA_CACHE
+        cd $NVIDIA_CACHE
+        curl -O -# http://developer.download.nvidia.com/compute/cuda/${CUDA_VERSION}/Prod/network_installers/mac/x86_64/cuda_mac_installer_tk.tar.gz
+        curl -O -# http://developer.download.nvidia.com/compute/cuda/${CUDA_VERSION}/Prod/network_installers/mac/x86_64/cuda_mac_installer_drv.tar.gz
     sudo tar -zxf cuda_mac_installer_tk.tar.gz -C /;
     sudo tar -zxf cuda_mac_installer_drv.tar.gz -C /;
-    rm -f cuda_mac_installer_tk.tar.gz cuda_mac_installer_drv.tar.gz
+    # Don't delete the tarballs for now because the N
+    # rm -f cuda_mac_installer_tk.tar.gz cuda_mac_installer_drv.tar.gz
+    # Now head back to work directory
+    cd $TRAVIS_BUILD_DIR
 
     # Install latex.
     export PATH="/usr/texbin:${PATH}:/usr/bin"

--- a/devtools/osx-build.sh
+++ b/devtools/osx-build.sh
@@ -2,6 +2,9 @@
 set -e -x
 export MACOSX_DEPLOYMENT_TARGET="10.9"
 # Update homebrew
+# Clear existing locks
+rm -rf /usr/local/var/homebrew/locks
+# Update homebrew (uses cache if available)
 brew uninstall -y brew-cask || brew untap -y caskroom/cask || 1
 brew update -y --quiet
 brew tap -y caskroom/cask
@@ -35,7 +38,7 @@ if [ "$INSTALL_OPENMM_PREREQUISITES" = true ] ; then
     fi
     sudo tar -zxf cuda_mac_installer_tk.tar.gz -C /;
     sudo tar -zxf cuda_mac_installer_drv.tar.gz -C /;
-    # Don't delete the tarballs for now because the N
+    # Don't delete the tarballs to cache the package
     # rm -f cuda_mac_installer_tk.tar.gz cuda_mac_installer_drv.tar.gz
     # Now head back to work directory
     cd $TRAVIS_BUILD_DIR


### PR DESCRIPTION
This PR enables Travis' Caching feature to cache the CUDA Mac installers to speed up the OSX build time. The caching feature saves up to 20 min on the OSX builds.

I have also changed how the Homebrew/Cask update is handled to shave a few more minutes off the boot. I tried caching that as well, but ran into issues where it was not saving time.

Overall, this reduces the OSX boot time from ~40 min to 20 min.