### PR TITLE
Update omnia build system to CUDA 9.0 and force openmm 7.2 beta build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,8 @@ services:
 
 env:
   global:
-    - CUDA_VERSION: "8.0"
-    - CUDA_SHORT_VERSION: "80"
+    - CUDA_VERSION: "9.0"
+    - CUDA_SHORT_VERSION: "90"
   secure:
     - "K3LSjERPC+kKtF3qeE0i6r0LNvmliJcZIgFCS2jJv24KBYRLhRQit+WD0KgyuSOlEgW80zU1qbqxWWLRkVhUGtaZvKEnQHLS8ww1akYLBoWbEjJv4p2B+MiHo2fa7G8AYw5L28Ahmb4C6+/3/KjapX2K0xd5w7bSWVF1+iZPnts="
 

--- a/openmm/meta.yaml
+++ b/openmm/meta.yaml
@@ -13,7 +13,7 @@ build:
 
 extra:
   upload: beta
-  force_upload: False
+  force_upload: True
 
 requirements:
   build:

--- a/openmm/run_test.py
+++ b/openmm/run_test.py
@@ -4,7 +4,7 @@ from simtk import openmm
 
 # Check major version number
 # If Z=0 for version X.Y.Z, out put is "X.Y"
-assert openmm.Platform.getOpenMMVersion() == '7.1.1', "openmm.Platform.getOpenMMVersion() = %s" % openmm.Platform.getOpenMMVersion()
+assert openmm.Platform.getOpenMMVersion() == '7.2', "openmm.Platform.getOpenMMVersion() = %s" % openmm.Platform.getOpenMMVersion()
 
 # Check git hash
-assert openmm.version.git_revision == 'c1a64aaa3b4b71f8dd9648fa724d2548a99d4ced', "openmm.version.git_revision = %s" % openmm.version.git_revision
+assert openmm.version.git_revision == '07c1b86c905870afac97bd54dd776433c1b602c2', "openmm.version.git_revision = %s" % openmm.version.git_revision


### PR DESCRIPTION
This PR makes some more changes in #837 
- [x] Update omnia build system to CUDA 9.0
- [x] Force openmm 7.2 beta to build and push (which may displace `dev`?)