### PR TITLE
Fixed error building OpenMM on Windows

### DIFF
--- a/openmm/bld.bat
+++ b/openmm/bld.bat
@@ -3,7 +3,7 @@ cd build
 
 set FFTW=C:\Miniconda3\pkgs\fftw3f-3.3.4-vc14_2\Library
 set APPSDK=C:\Program Files (x86)\AMD APP SDK\2.9-1
-set CUDASDK=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v9.0
+set CUDASDK=C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v9.0
 "C:\Program Files\CMake\bin\cmake.exe" .. -G "NMake Makefiles JOM" -DCMAKE_INSTALL_PREFIX=%PREFIX% -DCMAKE_BUILD_TYPE=Release -DOPENMM_GENERATE_API_DOCS=ON ^
     -DOPENCL_INCLUDE_DIR="%APPSDK%\include" -DOPENCL_LIBRARY="%APPSDK%\lib\x86_64\OpenCL.lib" ^
     -DFFTW_INCLUDES="%FFTW%/include" -DFFTW_LIBRARY="%FFTW%/lib/libfftw3f-3.lib" -DCUDA_TOOLKIT_ROOT_DIR="%CUDASDK%"

--- a/openmm/meta.yaml
+++ b/openmm/meta.yaml
@@ -8,7 +8,7 @@ source:
 
 
 build:
-  number: 0
+  number: 1
   skip: True # [win]
 
 extra:


### PR DESCRIPTION
Because *of course* using Windows style paths on Windows doesn't work correctly...