### PR TITLE
Experimental: Try setting the non-blocking flag in Python

### DIFF
--- a/devtools/docker-build.sh
+++ b/devtools/docker-build.sh
@@ -8,6 +8,8 @@ conda config --add channels conda-forge
 conda update -yq conda
 conda install -yq conda-build==2.1.17 jinja2 anaconda-client
 
+python -c 'import os,sys,fcntl; flags = fcntl.fcntl(sys.stdout, fcntl.F_GETFL); fcntl.fcntl(sys.stdout, fcntl.F_SETFL, flags&~os.O_NONBLOCK);'
+
 /io/conda-build-all -vvv $UPLOAD -- /io/*
 
 #mv /anaconda/conda-bld/linux-64/*tar.bz2 /io/ || true


### PR DESCRIPTION
May allow large sdtout flood not to cause travis to crash

xref #852