### PR TITLE
Use old travis trusty image since new one breaks our builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+# Use old trusty image since new one breaks our builds
+# See: https://blog.travis-ci.com/2017-12-12-new-trusty-images-q4-launch
+group: deprecated-2017Q4
+
 os:
   - linux
   - osx


### PR DESCRIPTION
See: https://blog.travis-ci.com/2017-12-12-new-trusty-images-q4-launch

This hopefully fixes the issue noted by @peastman in https://github.com/omnia-md/conda-recipes/pull/852#issuecomment-357307310