### PR TITLE
Update packmol to 18.013

### DIFF
--- a/packmol/meta.yaml
+++ b/packmol/meta.yaml
@@ -1,15 +1,15 @@
 package:
   name: packmol
-  version: "1!17.221"
+  version: "1!18.013"
 
 source:
   fn: packmol.tar.gz
-  url: https://github.com/mcubeg/packmol/archive/17.221.tar.gz
+  url: https://github.com/mcubeg/packmol/archive/18.013.tar.gz
 
 build:
-  number: 1
+  number: 0
   # no mingwpy support for py35 or py36 on win
-  skip: True  # [win and (py35 or py36)]
+  skip: True  # [win and py3k]
 
 requirements:
   build:
@@ -17,11 +17,11 @@ requirements:
     - python
     - mingwpy  [win]
     - gcc      [unix]
-    - libgfortran ==1.0 [linux]
+    - libgfortran [linux]
   run:
     - zlib
     - libgcc   [unix]
-    - libgfortran ==1.0 [linux]
+    - libgfortran [linux]
 
 test:
   commands:
@@ -29,5 +29,5 @@ test:
 
 about:
   home: http://www.ime.unicamp.br/~martinez/packmol/
-  license: GPL
+  license: MIT
   summary: Packing Optimization for Molecular Dynamics Simulations


### PR DESCRIPTION
Also drops the libgfortran 1.0 pin

