### PR TITLE
Update OpenMolTools to 0.8.3

### DIFF
--- a/openmoltools/meta.yaml
+++ b/openmoltools/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: openmoltools
-  version: 0.8.2
+  version: 0.8.3
 
 source:
-    url: https://github.com/choderalab/openmoltools/archive/0.8.2.tar.gz
-    fn: 0.8.2.tar.gz
+    url: https://github.com/choderalab/openmoltools/archive/0.8.3.tar.gz
+    fn: 0.8.3.tar.gz
 
 build:
   number: 0
@@ -39,7 +39,6 @@ requirements:
     - ambermini
     - pytables
     - parmed
-    - libgfortran 1.* # [linux]
 #    - rdkit    # rdkit is an optional dependency, may want to comment this out for the release version.
 
 test:


### PR DESCRIPTION
This is the last Python 2.7 release for this package