### PR TITLE
 Pin conda to a max to not break its API

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,7 +48,7 @@ environment:
 install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
   - set PATH=C:\MinGW\msys\1.0\bin;%PATH%
-  - conda update -yq --all
+  # - conda update -yq --all
   - conda install -yq conda==4.3.34 conda-build==2.1.17 jinja2 anaconda-client
   - conda config --add channels omnia
   - conda config --add channels conda-forge

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -49,7 +49,7 @@ install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
   - set PATH=C:\MinGW\msys\1.0\bin;%PATH%
   - conda update -yq --all
-  - conda install -yq conda\<=4.3.34 conda-build==2.1.17 jinja2 anaconda-client
+  - conda install -yq conda==4.3.34 conda-build==2.1.17 jinja2 anaconda-client
   - conda config --add channels omnia
   - conda config --add channels conda-forge
   - powershell .\\devtools\\appveyor\\missing-headers.ps1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -49,7 +49,7 @@ install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
   - set PATH=C:\MinGW\msys\1.0\bin;%PATH%
   - conda update -yq --all
-  - conda install -yq conda-build==2.1.17 jinja2 anaconda-client
+  - conda install -yq conda\<=4.3.34 conda-build==2.1.17 jinja2 anaconda-client
   - conda config --add channels omnia
   - conda config --add channels conda-forge
   - powershell .\\devtools\\appveyor\\missing-headers.ps1

--- a/devtools/docker-build.sh
+++ b/devtools/docker-build.sh
@@ -5,7 +5,7 @@ conda config --add channels omnia
 # Move the conda-forge channel to the top
 # Cannot just append omnia otherwise default would have higher priority
 conda config --add channels conda-forge
-conda update -yq conda
+conda install -yq conda\<=4.3.34
 conda install -yq conda-build==2.1.17 jinja2 anaconda-client
 
 /io/conda-build-all -vvv $UPLOAD -- /io/*

--- a/devtools/osx-build.sh
+++ b/devtools/osx-build.sh
@@ -12,7 +12,7 @@ bash Miniconda3-latest-MacOSX-x86_64.sh -b -p $HOME/anaconda;
 export PATH=$HOME/anaconda/bin:$PATH;
 conda config --add channels omnia;
 conda config --add channels conda-forge;
-conda update -yq conda;
+conda install conda\<=4.3.34;
 conda install -yq conda-env conda-build==2.1.7 jinja2 anaconda-client;
 conda config --show;
 

--- a/devtools/osx-build.sh
+++ b/devtools/osx-build.sh
@@ -12,7 +12,7 @@ bash Miniconda3-latest-MacOSX-x86_64.sh -b -p $HOME/anaconda;
 export PATH=$HOME/anaconda/bin:$PATH;
 conda config --add channels omnia;
 conda config --add channels conda-forge;
-conda install conda\<=4.3.34;
+conda install -yq conda\<=4.3.34;
 conda install -yq conda-env conda-build==2.1.7 jinja2 anaconda-client;
 conda config --show;
 


### PR DESCRIPTION
The actual fix is something I am working on so we have conda-build 3 compatibility and we can stop pinning to conda and conda-build, but many, many, many things changed and it will take a while to fix.

Since I don't know how long that will take, this is a stopgap to pin the conda version to stop this cycle of band-aid'ing while I get a proper fix in.