### PR TITLE
[fahmunge] Build fahmunge for osx too

### DIFF
--- a/fahmunge/meta.yaml
+++ b/fahmunge/meta.yaml
@@ -9,7 +9,7 @@ source:
 build:
   preserve_egg_dir: True
   number: 0
-  skip: True  # [not linux]
+  skip: True  # [not win]
 
 requirements:
   build:


### PR DESCRIPTION
This enables `osx` builds for `fahmunge`.