### PR TITLE
Unpin OpenMM's Sphinx dep.

### DIFF
--- a/openmm/meta.yaml
+++ b/openmm/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     # on osx, need to install doxygen manually
     - doxygen   [not osx]
     # for building docs
-    - sphinx ==1.5.6
+    - sphinx >=1.5.6
     - sphinxcontrib-bibtex
     - sphinxcontrib-lunrsearch
     - sphinxcontrib-autodoc_doxygen


### PR DESCRIPTION
I think we can safely unpin OpenMM's sphinx dependency from 1.5.6. I have tested locally and it appears to work.

We also need to unpin sphinx if we want to build on Python 3.7 since they are not making the old versions of sphinx on Py37.

We should not need to trigger new builds for Py 27, 35, or 36 since no code changes here, just the way the docs are compiled.

cc @peastman 