### PR TITLE
[WIP] Upgrade build system to support py37 and multi-CUDA builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ os:
   - linux
   - osx
 
+
 # Supported osx/xcode versions: https://docs.travis-ci.com/user/languages/objective-c/#Supported-Xcode-versions
 # See also: https://blog.travis-ci.com/2016-10-04-osx-73-default-image-live/
 osx_image: xcode6.4
@@ -25,35 +26,44 @@ services:
   - docker
 
 env:
-  global:
-    - CUDA_VERSION: "9.0"
-    - CUDA_SHORT_VERSION: "90"
+  matrix:
+    - CUDA_VERSION="7.5" CUDA_SHORT_VERSION="75"
+    - CUDA_VERSION="8.0" CUDA_SHORT_VERSION="80"
+    - CUDA_VERSION="9.0" CUDA_SHORT_VERSION="90"
+    - CUDA_VERSION="9.1" CUDA_SHORT_VERSION="91"
+    - CUDA_VERSION="9.2" CUDA_SHORT_VERSION="92"
+    - CUDA_VERSION="10.0" CUDA_SHORT_VERSION="100"
   secure:
     - "K3LSjERPC+kKtF3qeE0i6r0LNvmliJcZIgFCS2jJv24KBYRLhRQit+WD0KgyuSOlEgW80zU1qbqxWWLRkVhUGtaZvKEnQHLS8ww1akYLBoWbEjJv4p2B+MiHo2fa7G8AYw5L28Ahmb4C6+/3/KjapX2K0xd5w7bSWVF1+iZPnts="
 
+
 install:
-  # The Dockerfile that defines the image that for the build environment is
-  # available in this repo at devtools/omnia-build-box/Dockerfile
+  - export DOCKER_IMAGE="jchodera/omnia-linux-anvil:texlive18-cuda${CUDA_SHORT_VERSION}"
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-      docker pull jchodera/omnia-linux-anvil:texlive-amd30-cuda${CUDA_SHORT_VERSION};
+      docker pull ${DOCKER_IMAGE};
     fi
 
 script:
+  # Select upload destination
+  - export CHECK_AGAINST="--check-against omnia --check-against omnia/label/cuda${CUDA_SHORT_VERSION}"
+  #- export CHECK_AGAINST="$CHECK_AGAINST --check-against omnia/label/beta --check-against omnia/label/betacuda${CUDA_SHORT_VERSION}"
+  #- export CHECK_AGAISNT="$CHECK_AGAINST --check-against omnia/label/dev --check-against omnia/label/devcuda${CUDA_SHORT_VERSION}"
   - if [[ "${TRAVIS_PULL_REQUEST}" == "false" && "${TRAVIS_BRANCH}" == "master" ]]; then
-        export UPLOAD="--upload omnia";
+        export UPLOAD="$CHECK_AGAINST --upload omnia";
     else
-        export UPLOAD=" ";
+        export UPLOAD="%CHECK_AGAINST";
     fi
   - echo $UPLOAD
-
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
 
-        docker run -e UPLOAD -e BINSTAR_TOKEN -e TRAVIS_PULL_REQUEST
-            -t -i --rm -v `pwd`:/io jchodera/omnia-linux-anvil:texlive-amd30-cuda${CUDA_SHORT_VERSION}
+        docker run -e UPLOAD -e BINSTAR_TOKEN -e CUDA_VERSION -e CUDA_SHORT_VERSION -e TRAVIS_PULL_REQUEST
+            -t -i --rm -v `pwd`:/io ${DOCKER_IMAGE}
             bash /io/devtools/docker-build.sh;
 
     elif [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+
         echo "Building osx...";
         export NVIDIA_CACHE=$HOME/nvidia_cache;
         bash devtools/osx-build.sh;
+
     fi

--- a/conda-build-all
+++ b/conda-build-all
@@ -431,7 +431,7 @@ def build_package(m, python, numpy, args):
         else:
             print('Package failed to build (return code %s); will not upload.' % str(retcode))
 
-    #clean_builds()
+    clean_builds()
 
     sys.stdout.flush()
     return retcode
@@ -477,7 +477,8 @@ def execute(args, p):
         print()
     sys.stdout.flush()
 
-    to_build = list(required_builds(metadatas, pythons, numpys, channel_urls, verbose=args.verbose, force=args.force))
+    # Generate list of unique packages to build
+    to_build = list(set(required_builds(metadatas, pythons, numpys, channel_urls, verbose=args.verbose, force=args.force)))
 
     if len(to_build) > 0:
         print('[conda-build-all] Scheduling the following builds (%s):' % platform)

--- a/devtools/docker-build.sh
+++ b/devtools/docker-build.sh
@@ -1,14 +1,49 @@
 #!/bin/bash
+echo "CUDA_VERSION: $CUDA_VERSION"
+echo "PATH: $PATH"
+
 set -e
 set -x
+
+conda config --add channels conda-forge
 conda config --add channels omnia
 conda config --add channels omnia/label/dev
-# Move the conda-forge channel to the top
-# Cannot just append omnia otherwise default would have higher priority
-conda config --add channels conda-forge
-conda install -yq conda\<=4.3.34
-conda install -yq conda-build==2.1.17 jinja2 anaconda-client
 
-/io/conda-build-all -vvv $UPLOAD -- /io/*
+#conda install -yq conda\<=4.3.34
+#conda install -yq conda-build==2.1.17 jinja2 anaconda-client
+
+# Enable gcc compiler toolchain
+#source /opt/rh/devtoolset-2/enable
+#export PATH=/opt/rh/devtoolset-2/root/usr/bin${PATH:+:${PATH}}
+#export MANPATH=/opt/rh/devtoolset-2/root/usr/share/man:$MANPATH
+#export INFOPATH=/opt/rh/devtoolset-2/root/usr/share/info${INFOPATH:+:${INFOPATH}}
+#export PCP_DIR=/opt/rh/devtoolset-2/root
+# Some perl Ext::MakeMaker versions install things under /usr/lib/perl5
+# even though the system otherwise would go to /usr/lib64/perl5.
+#export PERL5LIB=/opt/rh/devtoolset-2/root//usr/lib64/perl5/vendor_perl:/opt/rh/devtoolset-2/root/usr/lib/perl5:/opt/rh/devtoolset-2/root//usr/share/perl5/vendor_perl${PERL5LIB:+:${PERL5LIB}}
+# bz847911 workaround:
+# we need to evaluate rpm's installed run-time % { _libdir }, not rpmbuild time
+# or else /etc/ld.so.conf.d files?
+#rpmlibdir=`rpm --eval "%{_libdir}"`
+# bz1017604: On 64-bit hosts, we should include also the 32-bit library path.
+#if [ "$rpmlibdir" != "${rpmlibdir/lib64/}" ]; then
+#  rpmlibdir32=":/opt/rh/devtoolset-2/root${rpmlibdir/lib64/lib}"
+#fi
+#export LD_LIBRARY_PATH=/opt/rh/devtoolset-2/root$rpmlibdir$rpmlibdir32${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+# duplicate python site.py logic for sitepackages
+#pythonvers=`python -c 'import sys; print sys.version[:3]'`
+#export PYTHONPATH=/opt/rh/devtoolset-2/root/usr/lib64/python$pythonvers/site-packages:/opt/rh/devtoolset-2/root/usr/lib/python$pythonvers/site-packages${PYTHONPATH:+:${PYTHONPATH}}
+
+# Enable conda
+#source /opt/docker/bin/entrypoint_source
+#for PY_BUILD_VERSION in "27" "35" "36" "37"; do
+
+# Make sure we have the appropriate channel added
+conda config --add channels omnia/label/betacuda${CUDA_SHORT_VERSION};
+conda config --add channels omnia/label/devcuda${CUDA_SHORT_VERSION};
+
+for PY_BUILD_VERSION in "37" "36" "35" "27" ; do
+    /io/conda-build-all -vvv --python $PY_BUILD_VERSION --check-against omnia/label/beta --check-against omnia/label/betacuda${CUDA_SHORT_VERSION} --check-against omnia/label/dev --check-against omnia/label/devcuda${CUDA_SHORT_VERSION} --numpy "1.15" $UPLOAD -- /io/*
+done
 
 #mv /anaconda/conda-bld/linux-64/*tar.bz2 /io/ || true

--- a/devtools/osx-build.sh
+++ b/devtools/osx-build.sh
@@ -12,13 +12,18 @@ bash Miniconda3-latest-MacOSX-x86_64.sh -b -p $HOME/anaconda;
 export PATH=$HOME/anaconda/bin:$PATH;
 conda config --add channels omnia;
 conda config --add channels conda-forge;
-conda config --add channels omnia/label/dev
 conda install -yq conda\<=4.3.34;
+#####################################################################
+# WORKAROUND FOR BUG WITH ruamel_yaml
+# "conda config --add channels omnia/label/dev" will fail if ruamel_yaml > 0.15.54
+# This workaround is in place to avoid this failure until this is patched
+# See: https://github.com/conda/conda/issues/7672
+conda install --yes ruamel_yaml==0.15.53 conda\<=4.3.34;
+#####################################################################
+conda config --add channels omnia/label/dev
 conda install -yq conda-env conda-build==2.1.7 jinja2 anaconda-client;
 conda config --show;
-
-# Clean up packages to reduce disk space usage.
-conda clean -pltis --yes;
+conda clean -tipsy;
 
 # Do this step last to make sure conda-build, conda-env, and conda updates come from the same channel first
 
@@ -29,12 +34,10 @@ if [ "$INSTALL_OPENMM_PREREQUISITES" = true ] ; then
     # Install OpenMM dependencies that can't be installed through
     # conda package manager (doxygen + CUDA)
     brew install -y https://raw.githubusercontent.com/Homebrew/homebrew-core/5b680fb58fedfb00cd07a7f69f5a621bb9240f3b/Formula/doxygen.rb
-    # Clean up after brew to save space
-    brew cleanup
     # Make the nvidia-cache if not there
     mkdir -p $NVIDIA_CACHE
     cd $NVIDIA_CACHE
-    # Download missing nvidia installers if not cached
+    # Download missing nvidia installers
     if ! [ -f cuda_mac_installer_tk.tar.gz ]; then
         curl -O -# http://developer.download.nvidia.com/compute/cuda/${CUDA_VERSION}/Prod/network_installers/mac/x86_64/cuda_mac_installer_tk.tar.gz
     fi
@@ -43,14 +46,14 @@ if [ "$INSTALL_OPENMM_PREREQUISITES" = true ] ; then
     fi
     sudo tar -zxf cuda_mac_installer_tk.tar.gz -C /;
     sudo tar -zxf cuda_mac_installer_drv.tar.gz -C /;
-    # TODO: Don't delete the tarballs so we can cache them, provided we have the space
+    # TODO: Don't delete the tarballs to cache the package, if we can spare the space
     rm -f cuda_mac_installer_tk.tar.gz cuda_mac_installer_drv.tar.gz
     # Now head back to work directory
     cd $TRAVIS_BUILD_DIR
 
     # Install latex.
     export PATH="/usr/texbin:${PATH}:/usr/bin"
-    brew cask install basictex
+    brew cask install --no-quarantine basictex
     mkdir -p /usr/texbin
     # Path based on https://github.com/caskroom/homebrew-cask/blob/master/Casks/basictex.rb location
     # .../texlive/{YEAR}basic/bin/{ARCH}/{Location of actual binaries}
@@ -61,10 +64,23 @@ if [ "$INSTALL_OPENMM_PREREQUISITES" = true ] ; then
     sleep 5
     sudo tlmgr --persistent-downloads --repository=$TLREPO install \
         titlesec framed threeparttable wrapfig multirow collection-fontsrecommended hyphenat xstring \
-        fncychap tabulary capt-of eqparbox environ trimspaces
-    # Clean up after brew to save space
-    brew cleanup
+        fncychap tabulary capt-of eqparbox environ trimspaces \
+        cmap fancybox titlesec framed fancyvrb threeparttable \
+        mdwtools wrapfig parskip upquote float multirow hyphenat caption \
+        xstring fncychap tabulary capt-of eqparbox environ trimspaces \
+        varwidth needspace
+    # Clean up brew
+    brew cleanup -s
 fi;
 
 # Build packages
-./conda-build-all -v $UPLOAD -- *
+export CUDA_SHORT_VERSION
+
+# Make sure we have the appropriate channel added
+conda config --add channels omnia/label/betacuda${CUDA_SHORT_VERSION};
+conda config --add channels omnia/label/devcuda${CUDA_SHORT_VERSION};
+
+#for PY_BUILD_VERSION in "27" "35" "36" "37"; do
+for PY_BUILD_VERSION in "37" "36" "35" "27"; do
+    ./conda-build-all -vvv --python $PY_BUILD_VERSION --check-against omnia/label/main --check-against omnia/label/devcuda${CUDA_SHORT_VERSION} --check-against omnia/label/rc --check-against omnia/label/rccuda${CUDA_SHORT_VERSION} --numpy "1.15" $UPLOAD -- *
+done


### PR DESCRIPTION
I'm a bit worried that the multi-CUDA builds will be a disaster for `conda-recipes`, so we may need to restrict the building of packages that require multi-CUDA builds to some other repo.

This will test how bad things might be.