### PR TITLE
Build python 2.7, 3.6, 3.7 and numpy 1.14, 1.15 to match conda-forge

### DIFF
--- a/devtools/docker-build.sh
+++ b/devtools/docker-build.sh
@@ -49,7 +49,7 @@ conda config --add channels omnia/label/rccuda${CUDA_SHORT_VERSION};
 #for PY_BUILD_VERSION in "37" "36" "35" "27" ; do
 #    /io/conda-build-all -vvv --python $PY_BUILD_VERSION --numpy "1.15" $UPLOAD -- /io/*
 #done
-    
-/io/conda-build-all -vvv --python "37,36,35,27" --numpy "1.15" $UPLOAD -- /io/*
+
+/io/conda-build-all -vvv --python "37,36,27" --numpy "1.14,1.15" $UPLOAD -- /io/*
 
 #mv /anaconda/conda-bld/linux-64/*tar.bz2 /io/ || true

--- a/devtools/osx-build.sh
+++ b/devtools/osx-build.sh
@@ -89,4 +89,4 @@ conda config --add channels omnia/label/betacuda${CUDA_SHORT_VERSION};
 #for PY_BUILD_VERSION in "37" "36" "35" "27"; do
 #    ./conda-build-all -vvv --python $PY_BUILD_VERSION --check-against omnia --check-against omnia/label/cuda${CUDA_SHORT_VERSION} --check-against omnia/label/beta --check-against omnia/label/betacuda${CUDA_SHORT_VERSION} --numpy "1.15" $UPLOAD -- *
 #done
-./conda-build-all -vvv --python "37,36,35,27" --numpy "1.15" $UPLOAD -- *
+./conda-build-all -vvv --python "37,36,27" --numpy "1.14,1.15" $UPLOAD -- *


### PR DESCRIPTION
This PR updates the python and numpy build matrix to match [`conda-forge` availability of `numpy` packages](https://anaconda.org/conda-forge/numpy/files):
* Python 2.7, 3.6, 3.7
* NumPy 1.14, 1.15