### PR TITLE
Remove md5 from shiftx2 package?

### DIFF
--- a/shiftx2/meta.yaml
+++ b/shiftx2/meta.yaml
@@ -9,7 +9,7 @@ source:
     - gcc.patch
 
 build:
-  number: 0
+  number: 1
   skip: True  # [not (py2k and linux)]
 
 requirements:

--- a/shiftx2/meta.yaml
+++ b/shiftx2/meta.yaml
@@ -5,7 +5,6 @@ package:
 source:
   fn: shiftx2-v110-linux-20160912.tgz
   url: http://www.shiftx2.ca/download/shiftx2-v110-linux-20160912.tgz
-  md5: be650b7cbc76034e2c4e77373e389fbc
   patches:
     - gcc.patch
 


### PR DESCRIPTION
This job https://travis-ci.org/mdtraj/mdtraj/jobs/478463660 fails with 
```
conda.CondaMultiError: Conda detected a mismatch between the expected content and downloaded content
for url 'https://conda.anaconda.org/omnia/linux-64/shiftx2-1.10-py27_0.tar.bz2'.
  download saved to: /home/travis/miniconda3/pkgs/shiftx2-1.10-py27_0.tar.bz2
  expected md5 sum: 25ac9ccb5d3a91f50de198b9c767ad86
  actual md5 sum: ecc17f52cf376b2bced5112bbdd01727
```

searching this repo for previous similar issues suggests that the fix for this is just to remove the md5sums from the package (https://github.com/omnia-md/conda-recipes/pull/700)? 