### PR TITLE
Update osx builds: Use xcode 9.4, target osx 10.10, skip CUDA/additional tex package installs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
+
+# Use old trusty image since new one breaks our builds
+# See: https://blog.travis-ci.com/2017-12-12-new-trusty-images-q4-launch
+#group: deprecated-2017Q4
+
 os:
   - linux
   - osx
@@ -5,7 +10,14 @@ os:
 
 # Supported osx/xcode versions: https://docs.travis-ci.com/user/languages/objective-c/#Supported-Xcode-versions
 # See also: https://blog.travis-ci.com/2016-10-04-osx-73-default-image-live/
-osx_image: osx_image: xcode9
+osx_image: xcode9.4
+addons:
+  homebrew:
+    casks:
+    - basictex
+    packages:
+    - doxygen
+    update: true
 
 #cache:
 #  directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,3 @@
-
-# Use old trusty image since new one breaks our builds
-# See: https://blog.travis-ci.com/2017-12-12-new-trusty-images-q4-launch
-group: deprecated-2017Q4
-
 os:
   - linux
   - osx
@@ -10,7 +5,7 @@ os:
 
 # Supported osx/xcode versions: https://docs.travis-ci.com/user/languages/objective-c/#Supported-Xcode-versions
 # See also: https://blog.travis-ci.com/2016-10-04-osx-73-default-image-live/
-osx_image: xcode6.4
+osx_image: xcode8.3
 
 #cache:
 #  directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ os:
 
 # Supported osx/xcode versions: https://docs.travis-ci.com/user/languages/objective-c/#Supported-Xcode-versions
 # See also: https://blog.travis-ci.com/2016-10-04-osx-73-default-image-live/
-osx_image: xcode8.3
+osx_image: osx_image: xcode9
 
 #cache:
 #  directories:

--- a/devtools/osx-build.sh
+++ b/devtools/osx-build.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 set -e -x
-export MACOSX_DEPLOYMENT_TARGET="10.9"
+export MACOSX_DEPLOYMENT_TARGET="10.10"
 # Clear existing locks
-rm -rf /usr/local/var/homebrew/locks
+#rm -rf /usr/local/var/homebrew/locks
 # Update homebrew cant disable this yet, -y and --quiet do nothing
-brew update
+#brew update
 
 # Install Miniconda
 curl -s -O https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh;
@@ -33,7 +33,7 @@ export INSTALL_OPENMM_PREREQUISITES=true
 if [ "$INSTALL_OPENMM_PREREQUISITES" = true ] ; then
     # Install OpenMM dependencies that can't be installed through
     # conda package manager (doxygen + CUDA)
-    brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/5b680fb58fedfb00cd07a7f69f5a621bb9240f3b/Formula/doxygen.rb
+    #brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/5b680fb58fedfb00cd07a7f69f5a621bb9240f3b/Formula/doxygen.rb
     # Make the nvidia-cache if not there
     mkdir -p $NVIDIA_CACHE
     cd $NVIDIA_CACHE
@@ -53,7 +53,7 @@ if [ "$INSTALL_OPENMM_PREREQUISITES" = true ] ; then
 
     # Install latex.
     export PATH="/usr/texbin:${PATH}:/usr/bin"
-    brew cask install --no-quarantine basictex
+    #brew cask install --no-quarantine basictex
     mkdir -p /usr/texbin
     # Path based on https://github.com/caskroom/homebrew-cask/blob/master/Casks/basictex.rb location
     # .../texlive/{YEAR}basic/bin/{ARCH}/{Location of actual binaries}
@@ -70,7 +70,7 @@ if [ "$INSTALL_OPENMM_PREREQUISITES" = true ] ; then
         xstring fncychap tabulary capt-of eqparbox environ trimspaces \
         varwidth needspace
     # Clean up brew
-    brew cleanup -s
+    #brew cleanup -s
 fi;
 
 # Build packages

--- a/devtools/osx-build.sh
+++ b/devtools/osx-build.sh
@@ -53,7 +53,7 @@ if [ "$INSTALL_OPENMM_PREREQUISITES" = true ] ; then
 
     # Install latex.
     export PATH="/usr/texbin:${PATH}:/usr/bin"
-    brew cask install --no-quarantine https://raw.githubusercontent.com/Homebrew/homebrew-cask/4fd6de716854f263382b2733199d19561f75b0aa/Casks/basictex.rb
+    brew cask install --no-quarantine basictex
     mkdir -p /usr/texbin
     # Path based on https://github.com/caskroom/homebrew-cask/blob/master/Casks/basictex.rb location
     # .../texlive/{YEAR}basic/bin/{ARCH}/{Location of actual binaries}

--- a/devtools/osx-build.sh
+++ b/devtools/osx-build.sh
@@ -53,7 +53,7 @@ if [ "$INSTALL_OPENMM_PREREQUISITES" = true ] ; then
 
     # Install latex.
     export PATH="/usr/texbin:${PATH}:/usr/bin"
-    brew cask install --no-quarantine https://github.com/Homebrew/homebrew-cask/blob/4fd6de716854f263382b2733199d19561f75b0aa/Casks/basictex.rb
+    brew cask install --no-quarantine https://raw.githubusercontent.com/Homebrew/homebrew-cask/4fd6de716854f263382b2733199d19561f75b0aa/Casks/basictex.rb
     mkdir -p /usr/texbin
     # Path based on https://github.com/caskroom/homebrew-cask/blob/master/Casks/basictex.rb location
     # .../texlive/{YEAR}basic/bin/{ARCH}/{Location of actual binaries}

--- a/devtools/osx-build.sh
+++ b/devtools/osx-build.sh
@@ -29,7 +29,7 @@ conda clean -tipsy;
 
 
 #export INSTALL_CUDA=`./conda-build-all --dry-run -- openmm`
-export INSTALL_OPENMM_PREREQUISITES=true
+export INSTALL_OPENMM_PREREQUISITES=false
 if [ "$INSTALL_OPENMM_PREREQUISITES" = true ] ; then
     # Install OpenMM dependencies that can't be installed through
     # conda package manager (doxygen + CUDA)

--- a/devtools/osx-build.sh
+++ b/devtools/osx-build.sh
@@ -53,7 +53,7 @@ if [ "$INSTALL_OPENMM_PREREQUISITES" = true ] ; then
 
     # Install latex.
     export PATH="/usr/texbin:${PATH}:/usr/bin"
-    brew cask install --no-quarantine basictex
+    brew cask install --no-quarantine https://github.com/Homebrew/homebrew-cask/blob/4fd6de716854f263382b2733199d19561f75b0aa/Casks/basictex.rb
     mkdir -p /usr/texbin
     # Path based on https://github.com/caskroom/homebrew-cask/blob/master/Casks/basictex.rb location
     # .../texlive/{YEAR}basic/bin/{ARCH}/{Location of actual binaries}


### PR DESCRIPTION
* Now that `xcode 6.4` has been deprecated:
![image](https://user-images.githubusercontent.com/3656088/57975008-9e062d80-798f-11e9-9f1d-1c5901de3503.png)
I've updated builds to use [`xcode` 9.4](https://docs.travis-ci.com/user/reference/osx/#macos-version) and the target osx version to 10.10.
* We now install brew packages via the [`addons`](https://docs.travis-ci.com/user/installing-dependencies/#installing-packages-on-macos) mechanism
* Since CUDA-dependent builds have moved to https://github.com/omnia-md/conda-recipes-cuda, I've commented out the CUDA toolkit installation (and additional TeX package install) for `osx` since this was causing problems with the docker image.