### PR TITLE
make osx conda downgrade also pin python to 3.6

### DIFF
--- a/devtools/osx-build.sh
+++ b/devtools/osx-build.sh
@@ -12,7 +12,7 @@ bash Miniconda3-latest-MacOSX-x86_64.sh -b -p $HOME/anaconda;
 export PATH=$HOME/anaconda/bin:$PATH;
 conda config --add channels conda-forge;
 conda config --add channels omnia;
-conda install -yq conda\<=4.3.34;
+conda install -yq conda\<=4.3.34 python=3.6;
 #####################################################################
 # WORKAROUND FOR BUG WITH ruamel_yaml
 # "conda config --add channels omnia/label/dev" will fail if ruamel_yaml > 0.15.54


### PR DESCRIPTION
https://openforcefieldgroup.slack.com/archives/C8NE3J96U/p1564504709107000

The omnia OSX travis jobs have started failing[1]. I started seeing this problem in my builds last night, and waited for the nightly cron job to run to see if it was just my PR, or if it was an overall problem. The cron job failed. So, I think it's a dependency that's changed. The most likely cause appears to be a new version of miniconda [2]. This miniconda release coincides with an update of the base conda to 4.7.10.
The cause of this error seems to be that the new miniconda builds a py37 environment (which it did before, no change there), but then dependencies resolve to more firmly pin python=3.7. Now, when we request an environment with conda install -yq 'conda<=4.3.34'[4], it is unable to downgrade to`python=3.6` (which it previously did at this point [3]) and raises an UnsatisfiableError [1]
As a patch, I could make the 'conda<=4.3.34'` version downgrade also force a downgrade to python=3.6 [4]. I'll open a PR to start testing this fix, but let me know if there's another way you'd like to approach the problem.
[1] Last night's cron job failure: https://travis-ci.org/omnia-md/conda-recipes/jobs/565293092#L403
[2] A miniconda release happened yesterday: https://repo.continuum.io/miniconda/
[3] Last successful cron job, python downgrade to 3.6: https://travis-ci.org/omnia-md/conda-recipes/jobs/564798613#L354
[4] Line that causes the crash, manual downgrade of conda to fix ruamel_yaml issue: https://github.com/omnia-md/conda-recipes/blob/master/devtools/osx-build.sh#L15