### PR TITLE
Fix travis failures

### DIFF
--- a/assaytools/meta.yaml
+++ b/assaytools/meta.yaml
@@ -8,7 +8,7 @@ source:
 
 build:
   number: 1
-  skip: True # [win]
+  skip: True # [win or py37]
 
 requirements:
   build:

--- a/protons/meta.yaml
+++ b/protons/meta.yaml
@@ -8,7 +8,7 @@ source:
 
 build:
   number: 0
-  skip: True # [win32 or py2k]
+  skip: True # fix later
 
 requirements:
   build:
@@ -70,4 +70,3 @@ test:
 about:
   home: https://github.com/choderalab/protons
   license: MIT
-  


### PR DESCRIPTION
* [assaytools] skip py37 since pymc2 not available for py37
* [protons] skip, since broken