### PR TITLE
[propertyestimator] 0.0.2 (label: rc) build 2

### DIFF
--- a/propertyestimator/meta.yaml
+++ b/propertyestimator/meta.yaml
@@ -8,7 +8,7 @@ source:
 
 build:
   preserve_egg_dir: True
-  number: 0 # Build number and string do not work together.
+  number: 1 # Build number and string do not work together.
   #string: py{{ py }}_a1 # Alpha version 1.
   skip: True # [win or py27 or py35]
 


### PR DESCRIPTION
omnia is only producing py37 packages for propertyestimator. This PR is to debug building the py36 packages. 