### PR TITLE
[openforcefield_forcefields] 1.0.0-RC1 (label: rc, build 2)

### DIFF
--- a/openforcefield_forcefields/meta.yaml
+++ b/openforcefield_forcefields/meta.yaml
@@ -7,7 +7,7 @@ source:
   git_tag: master
 
 build:
-  number: 1
+  number: 2
   #noarch: python
   entry_points:
     - openforcefield_forcefields = openforcefield_forcefields.openforcefield_forcefields:main


### PR DESCRIPTION
Rebuild now that there's both `openff-1.0.0-rc1` and `openff-hbonds-1.0.0-rc1`