### PR TITLE
fix build env definition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,10 +34,11 @@ services:
   - docker
 
 env:
-  matrix:
+  global:
+    secure:
+      - "K3LSjERPC+kKtF3qeE0i6r0LNvmliJcZIgFCS2jJv24KBYRLhRQit+WD0KgyuSOlEgW80zU1qbqxWWLRkVhUGtaZvKEnQHLS8ww1akYLBoWbEjJv4p2B+MiHo2fa7G8AYw5L28Ahmb4C6+/3/KjapX2K0xd5w7bSWVF1+iZPnts="
+  jobs:
     - CUDA_VERSION="9.2" CUDA_SHORT_VERSION="92"
-  secure:
-    - "K3LSjERPC+kKtF3qeE0i6r0LNvmliJcZIgFCS2jJv24KBYRLhRQit+WD0KgyuSOlEgW80zU1qbqxWWLRkVhUGtaZvKEnQHLS8ww1akYLBoWbEjJv4p2B+MiHo2fa7G8AYw5L28Ahmb4C6+/3/KjapX2K0xd5w7bSWVF1+iZPnts="
 
 
 install:


### PR DESCRIPTION
Something has changed about how Travis parses environment variables. It's probably related to [this change](https://changelog.travis-ci.com/more-secure-handling-of-secure-values-in-configuration-126390). I can't totally follow what's wrong here, since the change didn't completely break parsing of our `.travis.yml`, but instead just seems to have garbled it.

Either way, this PR basically restructures our job-definition code, replacing the `matrix` keyword with the `jobs` keyword that seems to be prevalent in current docs. 