### PR TITLE
Migrate all ambermini dependencies to ambertools; add openmm-forcefields

### DIFF
--- a/openforcefield/meta.yaml
+++ b/openforcefield/meta.yaml
@@ -8,7 +8,7 @@ source:
 
 build:
   preserve_egg_dir: True
-  number: 0 # Build number and string do not work together.
+  number: 1 # Build number and string do not work together.
   #string: py{{ py }}_a1 # Alpha version 1.
   skip: True # [win or py27 or py35]
 
@@ -33,9 +33,8 @@ requirements:
     - openforcefields
     - openmm
     - networkx
-    - parmed
     - rdkit
-    - ambermini
+    - ambertools
     - packaging
     - requests
     - notebook
@@ -46,7 +45,7 @@ requirements:
     - xmltodict
     - pyyaml
     - cairo >=1.16
-    
+
   run:
     - python
     - numpy
@@ -54,9 +53,8 @@ requirements:
     - openforcefields
     - openmm
     - networkx
-    - parmed
     - rdkit
-    - ambermini
+    - ambertools
     - packaging
     - requests
     - notebook

--- a/openmm-forcefields/build.sh
+++ b/openmm-forcefields/build.sh
@@ -1,9 +1,1 @@
 pip install .
-
-# Build sphinx docs
-DOCS_HOME=$PREFIX/docs/openforcefield
-cd docs
-# Build HTML manual
-make html
-mkdir -p $DOCS_HOME/html
-mv _build/html $DOCS_HOME

--- a/openmm-forcefields/build.sh
+++ b/openmm-forcefields/build.sh
@@ -1,0 +1,9 @@
+pip install .
+
+# Build sphinx docs
+DOCS_HOME=$PREFIX/docs/openforcefield
+cd docs
+# Build HTML manual
+make html
+mkdir -p $DOCS_HOME/html
+mv _build/html $DOCS_HOME

--- a/openmm-forcefields/build.sh
+++ b/openmm-forcefields/build.sh
@@ -1,1 +1,4 @@
-pip install .
+#!/bin/bash
+
+$PYTHON setup.py clean
+$PYTHON setup.py install

--- a/openmm-forcefields/meta.yaml
+++ b/openmm-forcefields/meta.yaml
@@ -1,0 +1,82 @@
+package:
+  name: openmm-forcefields
+  version: 0.7.1
+
+source:
+  git_url: https://github.com/openforcefield/openforcefield.git
+  git_tag: 0.7.1
+
+build:
+  preserve_egg_dir: True
+  number: 0 # Build number and string do not work together.
+  #string: py{{ py }}_a1 # Alpha version 1.
+  skip: True # [win or py27 or py35]
+
+extra:
+  #force_upload: True
+  upload: main # Upload to anaconda with the "main" label.
+
+requirements:
+  build:
+    # Base depends
+    - python
+    - pip
+
+    # Testing
+    - pytest
+    - pytest-cov
+    - codecov
+
+    # Requirements for converted force field installer
+    - openmm >=7.4.1
+
+    # Requirements for conversion tools
+    - pyyaml
+    - ambertools >=18.0 # contains sufficiently recent ParmEd
+    - lxml
+    - networkx
+
+    # JSON caching of residue templates
+    - tinydb
+
+    # openforcefield toolkit and force fields
+    - openforcefield >=0.6.0
+    - openforcefields >=1.0.0
+
+    # OpenEye toolkits are only used to speed up testing; they are not required for use
+    - openeye-toolkits
+
+  run:
+    # Base depends
+    - python
+    - pip
+
+    # Testing
+    - pytest
+    - pytest-cov
+    - codecov
+
+    # Requirements for converted force field installer
+    - openmm >=7.4.1
+
+    # Requirements for conversion tools
+    - pyyaml
+    - ambertools >=18.0 # contains sufficiently recent ParmEd
+    - lxml
+    - networkx
+
+    # JSON caching of residue templates
+    - tinydb
+
+    # openforcefield toolkit and force fields
+    - openforcefield >=0.6.0
+    - openforcefields >=1.0.0
+
+    # OpenEye toolkits are only used to speed up testing; they are not required for use
+    - openeye-toolkits
+
+about:
+  home: https://github.com/openforcefield/openforcefield
+  license: MIT
+  license_file: LICENSE
+  description: The Open Forcefield Toolkit provides implementations of the SMIRNOFF format, parameterization engine, and other tools.

--- a/openmm-forcefields/meta.yaml
+++ b/openmm-forcefields/meta.yaml
@@ -44,7 +44,7 @@ requirements:
     - openforcefields >=1.0.0
 
     # OpenEye toolkits are only used to speed up testing; they are not required for use
-    - openeye-toolkits
+    #- openeye-toolkits
 
   run:
     # Base depends
@@ -73,7 +73,7 @@ requirements:
     - openforcefields >=1.0.0
 
     # OpenEye toolkits are only used to speed up testing; they are not required for use
-    - openeye-toolkits
+    #- openeye-toolkits
 
 about:
   home: https://github.com/openforcefield/openforcefield

--- a/openmm-forcefields/meta.yaml
+++ b/openmm-forcefields/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: 0.7.1
 
 source:
-  git_url: https://github.com/openforcefield/openforcefield.git
+  git_url: https://github.com/openmm/openmm-forcefields.git
   git_tag: 0.7.1
 
 build:

--- a/openmoltools/meta.yaml
+++ b/openmoltools/meta.yaml
@@ -7,7 +7,7 @@ source:
     fn: 0.8.4.tar.gz
 
 build:
-  number: 1
+  number: 3
   skip: True # [win32 or (win and py2k)]
 
 requirements:
@@ -22,9 +22,8 @@ requirements:
     - scipy
     - pandas
     - openmm >=7.0.1
-    - ambermini
+    - ambertools
     - pytables
-    - parmed
 
   run:
     - python
@@ -36,9 +35,8 @@ requirements:
     - numpydoc
     - scipy
     - openmm >=7.0.1
-    - ambermini
+    - ambertools
     - pytables
-    - parmed
 
 test:
   requires:


### PR DESCRIPTION
This PR 
* Migrates `openforcefield` and `openmoltools` from depending on `ambermini` and `parmed` to just depending on the [new conda-forge `ambertools`](https://anaconda.org/conda-forge/ambertools/files) (which includes a recent `parmed`)
* Adds [`openmm-forcefields` 0.7.1](https://github.com/openmm/openmm-forcefields/releases/tag/0.7.1), though this will not work correctly for SMIRNOFF impropers unless the latest `omnia-dev` version of OpenMM is installed (which incorporates a critical extension https://github.com/openmm/openmm/pull/2511)