### PR TITLE
[openmmforcefields] Rename package openmm-forcefields -> openmmforcefields

### DIFF
--- a/openmm-forcefields/build.sh
+++ b/openmm-forcefields/build.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-$PYTHON setup.py clean
-$PYTHON setup.py install

--- a/openmmforcefields/build.sh
+++ b/openmmforcefields/build.sh
@@ -1,0 +1,1 @@
+$PYTHON setup.py install

--- a/openmmforcefields/meta.yaml
+++ b/openmmforcefields/meta.yaml
@@ -1,9 +1,9 @@
 package:
-  name: openmm-forcefields
+  name: openmmforcefields
   version: 0.7.1
 
 source:
-  git_url: https://github.com/openmm/openmm-forcefields.git
+  git_url: https://github.com/openmm/openmmforcefields.git
   git_tag: 0.7.1
 
 build:
@@ -76,7 +76,7 @@ requirements:
     #- openeye-toolkits
 
 about:
-  home: https://github.com/openforcefield/openforcefield
+  home: https://github.com/openmmforcefields/openmmforcefields
   license: MIT
   license_file: LICENSE
-  description: The Open Forcefield Toolkit provides implementations of the SMIRNOFF format, parameterization engine, and other tools.
+  description: Support for AMBER and CHARMM force fields and small molecule parameterization with GAFF and the Open Force Field Toolkit for OpenMM.


### PR DESCRIPTION
The discrepancy between `openmm-forcefields` and `openmmforcefields` was causing trouble, so this PR eliminates this issue.

I will delete the old `openmm-forcefields` packages from anaconda cloud.