### PR TITLE
[perses] 0.5.0 build 1 - update dependencies and allow openeye dependencies

### DIFF
--- a/devtools/docker-build.sh
+++ b/devtools/docker-build.sh
@@ -5,6 +5,7 @@ echo "PATH: $PATH"
 set -e
 set -x
 
+conda config --add channels openeye
 conda config --add channels conda-forge
 conda config --add channels omnia
 

--- a/perses/meta.yaml
+++ b/perses/meta.yaml
@@ -39,6 +39,7 @@ requirements:
     - tqdm
     - dask-jobqueue
     - openmmforcefields
+    - openeye-toolkits
 test:
   requires:
     - nose

--- a/perses/meta.yaml
+++ b/perses/meta.yaml
@@ -6,7 +6,7 @@ source:
   git_tag: 0.5.0
 build:
   preserve_egg_dir: True
-  number: 0
+  number: 1
   skip: True  # [win or py2k]
 requirements:
   build:
@@ -16,11 +16,11 @@ requirements:
   run:
     - python
     - setuptools
+    - ambertools >=19.11
     - numpy >=1.14
     - scipy
     - pymbar
-    - openmm >=7.3.0
-    - parmed
+    - openmm >=7.3.1
     - openmoltools >=0.8.4
     - openmmtools
     - numba
@@ -31,12 +31,14 @@ requirements:
     - pdbfixer
     - lxml
     - networkx >=2.0
-    #- openeye-toolkits # not on conda-forge
+    - openeye-toolkits
     - dask
     - distributed
     - yank
     - progressbar2
-    - parmed
+    - tqdm
+    - dask-jobqueue
+    - openmmforcefields
 test:
   requires:
     - nose


### PR DESCRIPTION
This updates the dependencies for `perses` to be consistent with the [current dependencies](https://github.com/choderalab/perses/blob/master/devtools/conda-recipe/meta.yaml).