### PR TITLE
[perses] 0.5.0 build 2 - fix issues with osx

### DIFF
--- a/assaytools/meta.yaml
+++ b/assaytools/meta.yaml
@@ -8,7 +8,8 @@ source:
 
 build:
   number: 1
-  skip: True # [win or py37]
+  #skip: True # [win or py37]
+  skip: True # skip for nos
 
 requirements:
   build:

--- a/devtools/docker-build.sh
+++ b/devtools/docker-build.sh
@@ -39,9 +39,9 @@ conda config --add channels omnia
 #for PY_BUILD_VERSION in "27" "35" "36" "37"; do
 
 # Make sure we have the appropriate channel added
-conda config --add channels omnia/label/cuda${CUDA_SHORT_VERSION};
-conda config --add channels omnia/label/rc;
-conda config --add channels omnia/label/rccuda${CUDA_SHORT_VERSION};
+#conda config --add channels omnia/label/cuda${CUDA_SHORT_VERSION};
+#conda config --add channels omnia/label/rc;
+#conda config --add channels omnia/label/rccuda${CUDA_SHORT_VERSION};
 #conda config --add channels omnia/label/beta;
 #conda config --add channels omnia/label/betacuda${CUDA_SHORT_VERSION};
 #conda config --add channels omnia/label/dev

--- a/devtools/osx-build.sh
+++ b/devtools/osx-build.sh
@@ -10,6 +10,7 @@ export MACOSX_DEPLOYMENT_TARGET="10.10"
 curl -s -O https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh;
 bash Miniconda3-latest-MacOSX-x86_64.sh -b -p $HOME/anaconda;
 export PATH=$HOME/anaconda/bin:$PATH;
+conda config --add channels openeye
 conda config --add channels conda-forge;
 conda config --add channels omnia;
 conda install -yq conda\<=4.3.34 python=3.6;
@@ -20,7 +21,7 @@ conda install -yq conda\<=4.3.34 python=3.6;
 # See: https://github.com/conda/conda/issues/7672
 conda install --yes ruamel_yaml==0.15.53 conda\<=4.3.34;
 #####################################################################
-conda config --add channels omnia/label/dev
+#conda config --add channels omnia-dev
 conda install -yq conda-env conda-build==2.1.7 jinja2 anaconda-client;
 conda config --show;
 conda clean -tipsy;

--- a/perses/meta.yaml
+++ b/perses/meta.yaml
@@ -6,7 +6,7 @@ source:
   git_tag: 0.5.0
 build:
   preserve_egg_dir: True
-  number: 1
+  number: 2
   skip: True  # [win or py2k]
 requirements:
   build:


### PR DESCRIPTION
This PR fixes issues with the `osx` build arising from the requirement for `openeye-toolkit` for `perses`.