### PR TITLE
[openforcefields] 1.1.1

### DIFF
--- a/openforcefields/meta.yaml
+++ b/openforcefields/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: openforcefields
-  version: "1.1.0"
+  version: "1.1.1"
 
 source:
   git_url: https://github.com/openforcefield/openforcefields.git
-  git_tag: 1.1.0
+  git_tag: 1.1.1
 
 build:
   number: 0


### PR DESCRIPTION
This will also contain the 1.0.1 release, but that won't get a separate package since they're being released simultaneously.