### PR TITLE
Revert NumPy<1.18 pin on Python 3.6

### DIFF
--- a/forcebalance/meta.yaml
+++ b/forcebalance/meta.yaml
@@ -7,7 +7,7 @@ source:
   fn: v1.7.2.tar.gz
 
 build:
-  number: 1
+  number: 2
   skip: True # [win]
 
 extra:

--- a/perses/meta.yaml
+++ b/perses/meta.yaml
@@ -12,14 +12,12 @@ requirements:
   build:
     - python
     - setuptools
-    - numpy >=1.14 # [not py36]
-    - numpy >=1.14,<1.18 # [py36]
+    - numpy >=1.14
   run:
     - python
     - setuptools
     - ambertools >=19.11
-    - numpy >=1.14 # [not py36]
-    - numpy >=1.14,<1.18 # [py36]
+    - numpy >=1.14
     - scipy
     - pymbar
     - openmm >=7.4.2


### PR DESCRIPTION
Related to https://github.com/omnia-md/conda-recipes/pull/1026 which may have been causing some issues downstream