### PR TITLE
[qcsubmit] 0.0.0

### DIFF
--- a/offline-builds/qcsubmit/README.md
+++ b/offline-builds/qcsubmit/README.md
@@ -1,0 +1,17 @@
+This is a recipe for building the current development package into a conda
+binary.
+
+The installation on travis-ci is done by building the conda package, installing
+it, running the tests, and then if successful pushing the package to binstar
+(and the docs to AWS S3). The binstar auth token is an encrypted environment
+variable generated using:
+
+binstar auth -n yank-travis -o omnia --max-age 22896000 -c --scopes api:write
+
+and then saved in the environment variable BINSTAR_TOKEN.
+
+You can set up travis to store an encrypted token via
+
+gem install travis travis encrypt BINSTAR_TOKEN=xx
+
+where xx is the token output by binstar. The final command should print a line (containing 'secure') for inclusion in your .travis.yml file.

--- a/offline-builds/qcsubmit/build.sh
+++ b/offline-builds/qcsubmit/build.sh
@@ -1,0 +1,2 @@
+pip install .
+

--- a/offline-builds/qcsubmit/build_local.sh
+++ b/offline-builds/qcsubmit/build_local.sh
@@ -1,0 +1,1 @@
+conda build --python=3.6 .

--- a/offline-builds/qcsubmit/meta.yaml
+++ b/offline-builds/qcsubmit/meta.yaml
@@ -1,0 +1,67 @@
+package:
+  name: qcsubmit
+  version: 0.0.0
+
+source:
+  git_url: https://github.com/openforcefield/qcsubmit.git
+  git_tag:  ac29b70
+
+build:
+  noarch: python
+  preserve_egg_dir: True
+  number: 0 # Build number and string do not work together.
+  #string: py{{ py }}_a1 # Alpha version 1.
+  skip: True # [win or py27 or py35]
+
+
+extra:
+  #force_upload: True
+  upload: main # Upload to anaconda with the "main" label.
+
+requirements:
+  build:
+    - python
+    - pip
+
+    # Testing
+    - pytest
+    - pytest-cov
+    - openforcefield >=0.7.0
+    - openforcefields
+    - smirnoff99Frosst
+    - openmmforcefields
+    - qcengine >=0.15.0
+    - pyyaml
+    - codecov
+    - qcportal
+    - openeye-toolkits
+    - qcfractal
+    - torsiondrive
+    - fragmenter
+
+
+  run:
+    - python
+    - pip
+
+    # Testing
+    - pytest
+    - pytest-cov
+    - openforcefield >=0.7.0
+    - openforcefields
+    - smirnoff99Frosst
+    - openmmforcefields
+    - qcengine >=0.15.0
+    - pyyaml
+    - codecov
+    - qcportal
+    - openeye-toolkits
+    - qcfractal
+    - torsiondrive
+    - fragmenter
+
+about:
+  home: https://github.com/openforcefield/qcsubmit
+  license: MIT
+  license_file: LICENSE
+  description: Automated tools for submitting molecules to QCFractal


### PR DESCRIPTION
To install:
```
conda create -n temp_qcsubmit -c conda-forge -c omnia/label/rc -c omnia -c openeye qcsubmit
conda activate temp_qcsubmit
pip install basis_set_exchange
```

Works for me on mac, fails with a version/git error on Linux.

@jthorton, could you try out the installation steps above and let me know if this works to your satisfaction (especially on Linux, if you have a machine available)?