### PR TITLE
[perses] Fix 0.7.1 

### DIFF
--- a/offline-builds/perses/meta.yaml
+++ b/offline-builds/perses/meta.yaml
@@ -6,7 +6,7 @@ source:
   git_tag: 0.7.1
 build:
   preserve_egg_dir: True
-  number: 2
+  number: 3
   skip: True  # [win or py2k]
 requirements:
   build:
@@ -25,7 +25,7 @@ requirements:
     - openmm >=7.4.2
     - parmed
     - openmoltools >=0.8.4
-    - openmmtools
+    - openmmtools >=0.20.0
     - numba
     - netcdf4
     - matplotlib

--- a/offline-builds/perses/meta.yaml
+++ b/offline-builds/perses/meta.yaml
@@ -5,9 +5,8 @@ source:
   git_url: https://github.com/choderalab/perses.git
   git_tag: 0.7.1
 build:
-  noarch: python
   preserve_egg_dir: True
-  number: 1
+  number: 2
   skip: True  # [win or py2k]
 requirements:
   build:


### PR DESCRIPTION
We can't use `noarch` since the `setup.py` contains an entry-point:
```

      entry_points={
       'openmm.forcefielddir' : ['perses=perses:get_datadir'],
       'console_scripts' : ['perses-relative = perses.app.setup_relative_calculation:run','perses-fah = perses.app.fah_generator:run']
      },
```
When you package with python 3.6, we end up with the entry point command-line executable that _only_ works if your environment is python 3.6:
```
#!/home/chodera/miniconda/envs/perses/bin/python3.6
# -*- coding: utf-8 -*-
import re
import sys
from perses.app.fah_generator import run
if __name__ == '__main__':
    sys.argv[0] = re.sub(r'(-script\.pyw|\.exe)?$', '', sys.argv[0])
    sys.exit(run())
```
So it's not really noarch as a result.

This PR un-does the `noarch` from #1054.

I've manually built and uploaded the packages for python 3.6 and 3.7 for `linux` and `osx`.
