### PR TITLE
[Perses] 0.7.1 build 6

### DIFF
--- a/offline-builds/perses/build.sh
+++ b/offline-builds/perses/build.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-pip install .

--- a/offline-builds/perses/meta.yaml
+++ b/offline-builds/perses/meta.yaml
@@ -13,7 +13,7 @@ build:
     - perses-relative = perses.app.setup_relative_calculation:run
     - perses-fah = perses.app.fah_generator:run
   script: 
-    - ${PYTHON}  -m pip install .  preserve_egg_dir: True
+    - ${PYTHON}  -m pip install .
 requirements:
   build:
     - python

--- a/offline-builds/perses/meta.yaml
+++ b/offline-builds/perses/meta.yaml
@@ -5,9 +5,15 @@ source:
   git_url: https://github.com/choderalab/perses.git
   git_tag: 0.7.1
 build:
+  noarch: python
   preserve_egg_dir: True
-  number: 4
+  number: 6
   skip: True  # [win or py2k]
+  entry_points:
+    - perses-relative = perses.app.setup_relative_calculation:run
+    - perses-fah = perses.app.fah_generator:run
+  script: 
+    - ${PYTHON}  -m pip install .  preserve_egg_dir: True
 requirements:
   build:
     - python


### PR DESCRIPTION
Trying to see if we can get a noarch build that doesn't have the problems of builds 0 and 1.

Removed build.sh, moved pip install to meta.yaml, included entry points in meta.yaml

To test:
`conda create --yes -n temp_perses6 -c conda-forge -c omnia/label/rc -c omnia -c openeye perses`