### PR TITLE
[fragmenter] 0.0.4 build 1

### DIFF
--- a/offline-builds/fragmenter/meta.yaml
+++ b/offline-builds/fragmenter/meta.yaml
@@ -7,8 +7,13 @@ source:
   fn: 0.0.4.tar.gz
 
 build:
-  number: 0
-  script: python -m pip install --no-deps --ignore-installed .
+  preserve_egg_dir: True
+  number: 1 # Build number and string do not work together.
+  #string: py{{ py }}_a1 # Alpha version 1.
+  skip: True # [win or py27 or py35]
+  noarch: python
+  script: 
+    - ${PYTHON}  -m pip install .
 
 requirements:
   build:
@@ -18,7 +23,7 @@ requirements:
   run:
     - python
     - setuptools
-    - openeye-toolkits
+    - openeye-toolkits<2020
     - rdkit
     - pyyaml
     - cmiles


### PR DESCRIPTION
Fragmenter is incompatible with OE2020, per https://github.com/openforcefield/fragmenter/issues/61

Putting this up as a reminder -- Will build package and test next week. 