### PR TITLE
[fragmenter] 0.0.7

### DIFF
--- a/offline-builds/fragmenter/meta.yaml
+++ b/offline-builds/fragmenter/meta.yaml
@@ -1,14 +1,14 @@
 package:
   name: fragmenter
-  version: 0.0.4
+  version: 0.0.7
 
 source:
-  url: https://github.com/openforcefield/fragmenter/archive/0.0.4.tar.gz
-  fn: 0.0.4.tar.gz
+  url: https://github.com/openforcefield/fragmenter/archive/0.0.7.tar.gz
+  fn: 0.0.7.tar.gz
 
 build:
   preserve_egg_dir: True
-  number: 1 # Build number and string do not work together.
+  number: 0 # Build number and string do not work together.
   #string: py{{ py }}_a1 # Alpha version 1.
   skip: True # [win or py27 or py35]
   noarch: python


### PR DESCRIPTION
@jthorton just pointed out that 0.0.4 is no longer the latest version of fragmenter, and actually has a conflict with the latest CMILES currently on conda forge. He can fix it by installing the latest fragmenter from master. So I'm updating the version of this package to the newest tag (0.0.7)