### PR TITLE
openforcefields-2.0.0-rc.1

### DIFF
--- a/offline-builds/openforcefields/meta.yaml
+++ b/offline-builds/openforcefields/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: openforcefields
-  version: "1.3.0"
+  version: "2.0.0rc.1"
 
 source:
   git_url: https://github.com/openforcefield/openforcefields.git
-  git_tag: 1.3.0
+  git_tag: 2.0.0-rc.1
 
 build:
   preserve_egg_dir: True


### PR DESCRIPTION
Per https://github.com/conda-forge/openff-forcefields-feedstock/pull/5, I'm manually making a `openforcefields` release with the sage release candidate, for the purposes of the conformer benchmarking project. 